### PR TITLE
Fixes startbit > 255 and table values with extended id's

### DIFF
--- a/DbcParserLib.Tests/DbcBuilderTests.cs
+++ b/DbcParserLib.Tests/DbcBuilderTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using DbcParserLib.Parsers;
-using DbcParserLib.Model;
-using Moq;
 using System.Linq;
+using DbcParserLib.Model;
+using DbcParserLib.Parsers;
+using Moq;
+using NUnit.Framework;
 
 namespace DbcParserLib.Tests
 {
@@ -256,6 +256,36 @@ namespace DbcParserLib.Tests
             Assert.AreEqual(message, dbc.Messages.First());
             Assert.AreEqual(signal, dbc.Messages.First().Signals.First());
             Assert.AreEqual("fake values", dbc.Messages.First().Signals.First().ValueTable);
+        }
+        [Test]
+        public void TableValuesWithExtendedMessageIdAreAddedToSignal()
+        {
+            var builder = new DbcBuilder();
+            var message = new Message { ID = 2566896411 };
+            message.IsExtID = CheckExtID(ref message.ID);
+            builder.AddMessage(message);
+            var signal = new Signal { Name = "name1" };
+            builder.AddSignal(signal);
+
+            builder.LinkTableValuesToSignal(2566896411, "name1", "fake values");
+            var dbc = builder.Build();
+
+            Assert.IsEmpty(dbc.Nodes);
+            Assert.AreEqual(1, dbc.Messages.Count());
+            Assert.AreEqual(message, dbc.Messages.First());
+            Assert.AreEqual(signal, dbc.Messages.First().Signals.First());
+            Assert.AreEqual("fake values", dbc.Messages.First().Signals.First().ValueTable);
+        }
+        private bool CheckExtID(ref uint id)
+        {
+            // For extended ID bit 31 is always 1
+            if (id >= 0x80000000)
+            {
+                id -= 0x80000000;
+                return true;
+            }
+            else
+                return false;
         }
 
         [Test]

--- a/DbcParserLib.Tests/ParserTests.cs
+++ b/DbcParserLib.Tests/ParserTests.cs
@@ -17,6 +17,20 @@ namespace DbcParserLib.Tests
             Assert.AreEqual(485, dbc.Messages.SelectMany(m => m.Signals).Count());
             Assert.AreEqual(15, dbc.Nodes.Count());
         }
+        [Test]
+        public void ParseMessageWithStartBitGreaterThan255Test()
+        {
+            var dbcString = @"
+BO_ 200 SENSOR: 39 SENSOR
+ SG_ SENSOR__rear m1 : 256|6@1+ (0.1,0) [0|0] ""  DBG
+ SG_ SENSOR__front m1 : 1755|1@1+ (0.1,0) [0|0] ""  DBG";
+
+
+            var dbc = Parser.Parse(dbcString);
+
+            Assert.AreEqual(1, dbc.Messages.Count());
+            Assert.AreEqual(2, dbc.Messages.SelectMany(m => m.Signals).Count());
+        }
 
         [Test]
         public void ParsingTwiceClearsCollectionsTest()

--- a/DbcParserLib/DbcBuilder.cs
+++ b/DbcParserLib/DbcBuilder.cs
@@ -66,10 +66,22 @@ namespace DbcParserLib
 
         public void LinkTableValuesToSignal(uint messageId, string signalName, string values)
         {
+            CheckExtID(ref messageId);
             if (TryGetValueMessageSignal(messageId, signalName, out var signal))
             {
                 signal.ValueTable = values;
             }
+        }
+        private bool CheckExtID(ref uint id)
+        {
+            // For extended ID bit 31 is always 1
+            if (id >= 0x80000000)
+            {
+                id -= 0x80000000;
+                return true;
+            }
+            else
+                return false;
         }
 
         private bool TryGetValueMessageSignal(uint messageId, string signalName, out Signal signal)

--- a/DbcParserLib/DbcParser.cs
+++ b/DbcParserLib/DbcParser.cs
@@ -39,7 +39,7 @@ namespace DbcParserLib
     {
         public uint ID;
         public string Name;
-        public byte StartBit;
+        public ushort StartBit;
         public byte Length;
         public byte ByteOrder = 1;
         public byte IsSigned;

--- a/DbcParserLib/DbcParserLib.csproj
+++ b/DbcParserLib/DbcParserLib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<OutputType>Library</OutputType>
-    <TargetFrameworks>net461;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net5.0;net6.0;netstandard2.0</TargetFrameworks>
     <Authors>Emanuel Feru</Authors>
     <Description>DbcParserLib is a .NET dbc file parser library for CAN network signals. This library can also be used to pack and unpack CAN signals.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/DbcParserLib/Parsers/SignalLineParser.cs
+++ b/DbcParserLib/Parsers/SignalLineParser.cs
@@ -54,7 +54,7 @@ namespace DbcParserLib.Parsers
             }
 
             sig.Name        = records[1];
-            sig.StartBit    = byte.Parse(records[3 + muxOffset], CultureInfo.InvariantCulture);
+            sig.StartBit    = ushort.Parse(records[3 + muxOffset], CultureInfo.InvariantCulture);
             sig.Length      = byte.Parse(records[4 + muxOffset], CultureInfo.InvariantCulture);
             sig.ByteOrder   = byte.Parse(records[5 + muxOffset].Substring(0, 1), CultureInfo.InvariantCulture);   // 0 = MSB (Motorola), 1 = LSB (Intel)
             sig.IsSigned    = (byte)(records[5 + muxOffset][1] == '+' ? 0 : 1);


### PR DESCRIPTION
Changed datatype to ushort for Signal.StartBit.  #7 
Added check for extended id in DbcBuilder  when linking table values. #10
Added netstandard2.0 as targetframeworks to support net core 3.1 #9  

