### PR TITLE
add IsInteger field

### DIFF
--- a/DbcParserLib/DbcParser.cs
+++ b/DbcParserLib/DbcParser.cs
@@ -45,6 +45,7 @@ namespace DbcParserLib
         public byte IsSigned;
         public double InitialValue;
         public double Factor = 1;
+        public bool IsInteger = false;
         public double Offset;
         public double Minimum;
         public double Maximum;
@@ -53,6 +54,15 @@ namespace DbcParserLib
         public string ValueTable;
         public string Comment;
         public string Multiplexing;
+        public static bool IsIntegerCheck(string str)
+        {
+            int r = 0;
+            if (int.TryParse(str, out r) == true)
+            {
+                return true;
+            }
+            return false;
+        }
     }
 
     [Obsolete("This class is obsolete and will be removed in the future. Use Parser class instead.", false)]
@@ -190,7 +200,8 @@ namespace DbcParserLib
                 sig.IsSigned = 0;
             else
                 sig.IsSigned = 1;
-
+            var factorStr = records[6 + mux].Split(new string[] { "," }, StringSplitOptions.None)[0];
+            sig.IsInteger = Signal.IsIntegerCheck(factorStr);
             sig.Factor      = double.Parse(records[6 + mux].Split(new string[] { "," }, StringSplitOptions.None)[0], CultureInfo.InvariantCulture);
             sig.Offset      = double.Parse(records[6 + mux].Split(new string[] { "," }, StringSplitOptions.None)[1], CultureInfo.InvariantCulture);
             sig.Minimum     = double.Parse(records[7 + mux], CultureInfo.InvariantCulture);

--- a/DbcParserLib/Parsers/SignalLineParser.cs
+++ b/DbcParserLib/Parsers/SignalLineParser.cs
@@ -58,7 +58,8 @@ namespace DbcParserLib.Parsers
             sig.Length      = byte.Parse(records[4 + muxOffset], CultureInfo.InvariantCulture);
             sig.ByteOrder   = byte.Parse(records[5 + muxOffset].Substring(0, 1), CultureInfo.InvariantCulture);   // 0 = MSB (Motorola), 1 = LSB (Intel)
             sig.IsSigned    = (byte)(records[5 + muxOffset][1] == '+' ? 0 : 1);
-
+            var factorStr = records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0];
+            sig.IsInteger= Signal.IsIntegerCheck(factorStr);
             sig.Factor      = double.Parse(records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0], CultureInfo.InvariantCulture);
             sig.Offset      = double.Parse(records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[1], CultureInfo.InvariantCulture);
             sig.Minimum     = double.Parse(records[7 + muxOffset], CultureInfo.InvariantCulture);
@@ -81,7 +82,7 @@ namespace DbcParserLib.Parsers
 
             if (match.Success == false)
                 return;
-
+            var factorStr = match.Groups[7].Value;
             var sig = new Signal
             {
                 Multiplexing = match.Groups[2].Value,
@@ -90,6 +91,7 @@ namespace DbcParserLib.Parsers
                 Length = byte.Parse(match.Groups[4].Value, CultureInfo.InvariantCulture),
                 ByteOrder = byte.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture),   // 0 = MSB (Motorola), 1 = LSB (Intel)
                 IsSigned = (byte)(match.Groups[6].Value == SignedSymbol ? 1 : 0),
+                IsInteger= Signal.IsIntegerCheck(factorStr),
                 Factor = double.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture),
                 Offset = double.Parse(match.Groups[8].Value, CultureInfo.InvariantCulture),
                 Minimum = double.Parse(match.Groups[9].Value, CultureInfo.InvariantCulture),


### PR DESCRIPTION
I need to know if Signal is an integer or a float/double, because it needs to be used to generate C code:
```
public static class SignalExtensions
    {
        public static string GetCppType(this Signal signal)
        {
            string su = string.Empty;
            string type=string.Empty;
            if(signal.IsInteger==true)
            {
                if (signal.IsSigned == 0)
                {
                    su = "u";
                }
                if (signal.Length <= 8)
                {
                    type = "int8_t";
                }
                else if (signal.Length <= 16)
                {
                    type = "int16_t";
                }
                else if (signal.Length <= 32)
                {
                    type = "int32_t";
                }
                else if (signal.Length <= 64)
                {
                    type = "int64_t";
                }
                else
                {
                    throw new Exception("不支持的类型");
                }
                return su + type;
            }
            else
            {
                if (signal.Length <= 32)
                {
                    type = "float";
                }
                else if (signal.Length <= 64)
                {
                    type = "double";
                }
                return type;
            }
            
        }
    }
```