### PR TITLE
3 add support for float and double value type

### DIFF
--- a/DbcParserLib.Tests/CommentLineParserTests.cs
+++ b/DbcParserLib.Tests/CommentLineParserTests.cs
@@ -4,6 +4,7 @@ using Moq;
 
 namespace DbcParserLib.Tests
 {
+    [TestFixture]
     public class CommentLineParserTests
     {
         private MockRepository m_repository;

--- a/DbcParserLib.Tests/PackerTests.cs
+++ b/DbcParserLib.Tests/PackerTests.cs
@@ -19,11 +19,101 @@ namespace DbcParserLib.Tests
                 Offset = 20
             };
 
-            ulong TxMsg = Packer.TxSignalPack(-34.3, sig);
-            Assert.AreEqual(43816, TxMsg);
+            var txMsg = Packer.TxSignalPack(-34.3, sig);
+            Assert.AreEqual(43816, txMsg);
 
-            double val = Packer.RxSignalUnpack(TxMsg, sig);
+            var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(-34.3, val, 1e-2);
+        }
+
+        [TestCase((ushort)0, 3255382835ul)]
+        [TestCase((ushort)2, 13021531340ul)]
+        [TestCase((ushort)5, 104172250720ul)]
+        [TestCase((ushort)12, 13334048092160ul)]
+        public void FloatLittleEndianValuePackingTest(ushort start, ulong packet)
+        {
+            var sig = new Signal
+            {
+                Length = 32,
+                StartBit = start,
+                ValueType = DbcValueType.IEEEFloat,
+                ByteOrder = 1, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
+                Factor = 1,
+                Offset = 0
+            };
+
+            var expected = -34.3f;
+            var txMsg = Packer.TxSignalPack(expected, sig);
+            Assert.AreEqual(packet, txMsg);
+
+            var val = Packer.RxSignalUnpack(txMsg, sig);
+            Assert.AreEqual(expected, val, 1e-2);
+        }
+
+        [TestCase((ushort)0, 439799153665ul)]
+        [TestCase((ushort)2, 655406731270ul)]
+        [TestCase((ushort)5, 828061286960ul)]
+        [TestCase((ushort)12, 105991844730880ul)]
+        public void FloatBigEndianValuePackingTest(ushort start, ulong packet)
+        {
+            var sig = new Signal
+            {
+                Length = 32,
+                StartBit = start,
+                ValueType = DbcValueType.IEEEFloat,
+                ByteOrder = 0, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
+                Factor = 1,
+                Offset = 0
+            };
+
+            var value = -34.3f;
+            var txMsg = Packer.TxSignalPack(value, sig);
+            Assert.AreEqual(packet, txMsg);
+
+            var val = Packer.RxSignalUnpack(txMsg, sig);
+            Assert.AreEqual(value, val, 1e-2);
+        }
+
+        [Test]
+        public void DoubleLittleEndianValuePackingTest()
+        {
+            var sig = new Signal
+            {
+                Length = 64,
+                StartBit = 0,
+                ValueType = DbcValueType.IEEEDouble,
+                ByteOrder = 1, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
+                Factor = 1,
+                Offset = 0
+            };
+
+            var expected = -34.3567;
+            var txMsg = Packer.TxSignalPack(expected, sig);
+            Assert.AreEqual(13853404129830452697, txMsg);
+
+            var val = Packer.RxSignalUnpack(txMsg, sig);
+            Assert.AreEqual(expected, val, 1e-2);
+        }
+
+        [Test]
+        public void DoubleBigEndianValuePackingTest()
+        {
+            var sig = new Signal
+            {
+                Length = 64,
+                StartBit = 7,
+                ValueType = DbcValueType.IEEEDouble,
+                ByteOrder = 0, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
+                Factor = 1,
+                Offset = 0
+            };
+
+            var expected = -34.35564;
+            var txMsg = Packer.TxSignalPack(expected, sig);
+            Assert.AreEqual(2419432028705210816, txMsg);
+
+            var val = Packer.RxSignalUnpack(txMsg, sig);
+            Assert.AreEqual(expected, val, 1e-2);
         }
 
         [Test]
@@ -39,10 +129,10 @@ namespace DbcParserLib.Tests
                 Offset = 0
             };
 
-            ulong TxMsg = Packer.TxSignalPack(800, sig);
-            Assert.AreEqual(107374182400, TxMsg);
+            var txMsg = Packer.TxSignalPack(800, sig);
+            Assert.AreEqual(107374182400, txMsg);
 
-            double val = Packer.RxSignalUnpack(TxMsg, sig);
+            var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(800, val);
 
             val = Packer.RxSignalUnpack(9655716608953581040, sig);
@@ -62,10 +152,10 @@ namespace DbcParserLib.Tests
                 Offset = 0
             };
 
-            ulong TxMsg = Packer.TxSignalPack(396.31676720860366, sig);
-            Assert.AreEqual(3963167672086036480, TxMsg);
+            var txMsg = Packer.TxSignalPack(396.31676720860366, sig);
+            Assert.AreEqual(3963167672086036480, txMsg);
 
-            double val = Packer.RxSignalUnpack(TxMsg, sig);
+            var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(396.31676720860366, val);
         }
 
@@ -83,10 +173,10 @@ namespace DbcParserLib.Tests
                 Offset = -125
             };
 
-            ulong TxMsg = Packer.TxSignalPack(8, sig);
-            Assert.AreEqual(9583660007044415488, TxMsg);
+            var txMsg = Packer.TxSignalPack(8, sig);
+            Assert.AreEqual(9583660007044415488, txMsg);
 
-            double val = Packer.RxSignalUnpack(TxMsg, sig);
+            var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(8, val);
 
             val = Packer.RxSignalUnpack(9655716608953581040, sig);
@@ -107,10 +197,10 @@ namespace DbcParserLib.Tests
                 Offset = 0
             };
 
-            ulong TxMsg = Packer.TxSignalPack(1, sig);
-            Assert.AreEqual(262144, TxMsg);
+            var txMsg = Packer.TxSignalPack(1, sig);
+            Assert.AreEqual(262144, txMsg);
 
-            double val = Packer.RxSignalUnpack(TxMsg, sig);
+            var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(1, val);
 
             val = Packer.RxSignalUnpack(140737488617472, sig);
@@ -131,10 +221,10 @@ namespace DbcParserLib.Tests
                 Offset = 0
             };
 
-            ulong TxMsg = Packer.TxSignalPack(6, sig);
-            Assert.AreEqual(384, TxMsg);
+            var txMsg = Packer.TxSignalPack(6, sig);
+            Assert.AreEqual(384, txMsg);
 
-            double val = Packer.RxSignalUnpack(TxMsg, sig);
+            var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(6, val);
 
             val = Packer.RxSignalUnpack(498806260540323729, sig);

--- a/DbcParserLib.Tests/PackerTests.cs
+++ b/DbcParserLib.Tests/PackerTests.cs
@@ -13,7 +13,7 @@ namespace DbcParserLib.Tests
             {
                 Length = 14,
                 StartBit = 2,
-                IsSigned = 1,
+                ValueType = DbcValueType.Signed,
                 ByteOrder = 1, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
                 Factor = 0.01,
                 Offset = 20
@@ -33,7 +33,7 @@ namespace DbcParserLib.Tests
             {
                 Length = 16,
                 StartBit = 24,
-                IsSigned = 1,
+                ValueType = DbcValueType.Signed,
                 ByteOrder = 1, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
                 Factor = 0.125,
                 Offset = 0
@@ -48,7 +48,7 @@ namespace DbcParserLib.Tests
             val = Packer.RxSignalUnpack(9655716608953581040, sig);
             Assert.AreEqual(800, val);
         }
-        
+
         [Test]
         public void PackingTest64Bit()
         {
@@ -56,7 +56,7 @@ namespace DbcParserLib.Tests
             {
                 Length = 64,
                 StartBit = 0,
-                IsSigned = 1,
+                ValueType = DbcValueType.Signed,
                 ByteOrder = 1, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
                 Factor = 1e-16,
                 Offset = 0
@@ -77,7 +77,7 @@ namespace DbcParserLib.Tests
             {
                 Length = 8,
                 StartBit = 56,
-                IsSigned = 0,
+                ValueType = DbcValueType.Unsigned,
                 ByteOrder = 1, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
                 Factor = 1,
                 Offset = -125
@@ -101,7 +101,7 @@ namespace DbcParserLib.Tests
             {
                 Length = 1,
                 StartBit = 18,
-                IsSigned = 0,
+                ValueType = DbcValueType.Unsigned,
                 ByteOrder = 1, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
                 Factor = 1,
                 Offset = 0
@@ -125,7 +125,7 @@ namespace DbcParserLib.Tests
             {
                 Length = 3,
                 StartBit = 6,
-                IsSigned = 0,
+                ValueType = DbcValueType.Unsigned,
                 ByteOrder = 1, // 0 = Big Endian (Motorola), 1 = Little Endian (Intel)
                 Factor = 1,
                 Offset = 0

--- a/DbcParserLib.Tests/SignalValueTypeLineParserTests.cs
+++ b/DbcParserLib.Tests/SignalValueTypeLineParserTests.cs
@@ -1,0 +1,124 @@
+using DbcParserLib.Model;
+using DbcParserLib.Parsers;
+using Moq;
+using NUnit.Framework;
+
+namespace DbcParserLib.Tests
+{
+    [TestFixture]
+    public class SignalValueTypeLineParserTests
+    {
+        private MockRepository m_repository;
+
+        [SetUp]
+        public void Setup()
+        {
+            m_repository = new MockRepository(MockBehavior.Strict);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            m_repository.VerifyAll();
+        }
+
+        private static ILineParser CreateParser()
+        {
+            return new SignalValueTypeLineParser();
+        }
+
+        [Test]
+        public void EmptyCommentLineIsIgnored()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            Assert.IsFalse(commentLineParser.TryParse(string.Empty, dbcBuilderMock.Object));
+        }
+
+        [Test]
+        public void RandomStartIsIgnored()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            Assert.IsFalse(commentLineParser.TryParse("xfsgt_", dbcBuilderMock.Object));
+        }
+
+        [Test]
+        public void OnlyPrefixIsIgnored()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            Assert.IsFalse(commentLineParser.TryParse("SIG_VALTYPE_ ", dbcBuilderMock.Object));
+        }
+
+        [Test]
+        public void PrefixAndMessageIsIgnored()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            Assert.IsFalse(commentLineParser.TryParse("SIG_VALTYPE_ 32 ", dbcBuilderMock.Object));
+        }
+
+        [Test]
+        public void PrefixMessageAndSignalIsIgnored()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            Assert.IsFalse(commentLineParser.TryParse("SIG_VALTYPE_ 32 signal", dbcBuilderMock.Object));
+        }
+
+        [Test]
+        public void FullLineIsParsed()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            Assert.IsTrue(commentLineParser.TryParse("SIG_VALTYPE_ 32 signal 0", dbcBuilderMock.Object));
+        }
+
+        [Test]
+        public void MessageMustBeANumber()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            Assert.IsFalse(commentLineParser.TryParse("SIG_VALTYPE_ xxx signal 0", dbcBuilderMock.Object));
+        }
+
+        [Test]
+        public void ValueMustBeANumber()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            Assert.IsFalse(commentLineParser.TryParse("SIG_VALTYPE_ 45 signal xx", dbcBuilderMock.Object));
+        }
+
+        [Test]
+        public void ValueOneCallsFloat()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            dbcBuilderMock.Setup(x => x.AddSignalValueType(45, "signal", DbcValueType.IEEEFloat));
+
+            Assert.IsTrue(commentLineParser.TryParse("SIG_VALTYPE_ 45 signal 1", dbcBuilderMock.Object));
+        }
+
+        [Test]
+        public void ValueTwoCallsDouble()
+        {
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var commentLineParser = CreateParser();
+
+            dbcBuilderMock.Setup(x => x.AddSignalValueType(45, "signal", DbcValueType.IEEEDouble));
+
+            Assert.IsTrue(commentLineParser.TryParse("SIG_VALTYPE_ 45 signal 2", dbcBuilderMock.Object));
+        }
+    }
+}

--- a/DbcParserLib/DbcBuilder.cs
+++ b/DbcParserLib/DbcBuilder.cs
@@ -52,6 +52,14 @@ namespace DbcParserLib
             }
         }
 
+        public void AddSignalValueType(uint messageId, string signalName, DbcValueType valueType)
+        {
+            if (TryGetValueMessageSignal(messageId, signalName, out var signal))
+            {
+                signal.ValueType = valueType;
+            }
+        }
+
         public void AddNodeComment(string nodeName, string comment)
         {
             var node = m_nodes.FirstOrDefault(n => n.Name.Equals(nodeName));

--- a/DbcParserLib/IDbcBuilder.cs
+++ b/DbcParserLib/IDbcBuilder.cs
@@ -13,6 +13,7 @@ namespace DbcParserLib
         void AddSignal(Signal signal);
         void AddSignalComment(uint messageId, string signalName, string comment);
         void AddSignalInitialValue(uint messageId, string signalName, double initialValue);
+        void AddSignalValueType(uint messageId, string signalName, DbcValueType valueType);
         void LinkNamedTableToSignal(uint messageId, string signalName, string tableName);
         void LinkTableValuesToSignal(uint messageId, string signalName, string values);
     }

--- a/DbcParserLib/Model/Node.cs
+++ b/DbcParserLib/Model/Node.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace DbcParserLib.Model
@@ -27,7 +28,9 @@ namespace DbcParserLib.Model
         public ushort StartBit;
         public ushort Length;
         public byte ByteOrder = 1;
+        [Obsolete("Please use ValueType instead. IsSigned will be removed in future releases")]
         public byte IsSigned;
+        public DbcValueType ValueType;
         public double InitialValue;
         public double Factor = 1;
         public bool IsInteger = false;
@@ -39,5 +42,10 @@ namespace DbcParserLib.Model
         public string ValueTable;
         public string Comment;
         public string Multiplexing;
+    }
+
+    public enum DbcValueType
+    {
+        Signed, Unsigned, IEEEFloat, IEEEDouble
     }
 }

--- a/DbcParserLib/Model/Node.cs
+++ b/DbcParserLib/Model/Node.cs
@@ -23,14 +23,27 @@ namespace DbcParserLib.Model
 
     public class Signal
     {
+        private DbcValueType m_ValueType = DbcValueType.Signed;
+
         public uint ID;
         public string Name;
         public ushort StartBit;
         public ushort Length;
         public byte ByteOrder = 1;
         [Obsolete("Please use ValueType instead. IsSigned will be removed in future releases")]
-        public byte IsSigned;
-        public DbcValueType ValueType;
+        public byte IsSigned { get; private set; } = 1;
+        public DbcValueType ValueType
+        {
+            get
+            {
+                return m_ValueType;
+            }
+            set
+            {
+                m_ValueType = value;
+                IsSigned = (byte)(value == DbcValueType.Unsigned ? 0 : 1);
+            }
+        }
         public double InitialValue;
         public double Factor = 1;
         public bool IsInteger = false;

--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -28,13 +28,13 @@ namespace DbcParserLib
             iVal = (int64_T)Math.Round((value - signal.Offset) / signal.Factor);
     
             // Apply overflow protection
-            if (signal.IsSigned != 0)
+            if (signal.ValueType == DbcValueType.Signed)
                 iVal = CLAMP(iVal, -(int64_T)(bitMask >> 1) - 1, (int64_T)(bitMask >> 1));
             else
                 iVal = CLAMP(iVal, 0L, (int64_T)bitMask);
 
             // Manage sign bit (if signed)
-            if (signal.IsSigned != 0 && iVal < 0) {
+            if (signal.ValueType == DbcValueType.Signed && iVal < 0) {
               iVal += (int64_T)(1UL << signal.Length);
             }
 
@@ -83,7 +83,7 @@ namespace DbcParserLib
                 iVal = (int64_T)((MirrorMsg(RxMsg64) >> GetStartBitLE(signal)) & bitMask);
 
             // Manage sign bit (if signed)
-            if (signal.IsSigned != 0) {
+            if (signal.ValueType == DbcValueType.Signed) {
               iVal -= ((iVal >> (signal.Length - 1)) != 0) ? (1L << signal.Length) : 0L;
             }
 

--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -39,7 +39,7 @@ namespace DbcParserLib
             }
 
             // Pack signal
-            if (signal.ByteOrder != 0)  // Little endian (Intel)
+            if (signal.Intel())  // Little endian (Intel)
                 return (((uint64_T)iVal & bitMask) << signal.StartBit);
             else                        // Big endian (Motorola)
                 return MirrorMsg(((uint64_T)iVal & bitMask) << GetStartBitLE(signal));
@@ -59,7 +59,7 @@ namespace DbcParserLib
             value = CLAMP(value, 0UL, bitMask);
     
             // Pack signal
-            if (signal.ByteOrder != 0)  // Little endian (Intel)
+            if (signal.Intel())  // Little endian (Intel)
                 return ((value & bitMask) << signal.StartBit);
             else                        // Big endian (Motorola)
                 return MirrorMsg((value & bitMask) << GetStartBitLE(signal));
@@ -77,7 +77,7 @@ namespace DbcParserLib
             uint64_T bitMask = signal.BitMask();
 
             // Unpack signal
-            if (signal.ByteOrder != 0)  // Little endian (Intel)
+            if (signal.Intel())  // Little endian (Intel)
                 iVal = (int64_T)((RxMsg64 >> signal.StartBit) & bitMask);
             else                        // Big endian (Motorola)
                 iVal = (int64_T)((MirrorMsg(RxMsg64) >> GetStartBitLE(signal)) & bitMask);
@@ -103,7 +103,7 @@ namespace DbcParserLib
             uint64_T bitMask = signal.BitMask();
 
             // Unpack signal
-            if (signal.ByteOrder != 0)  // Little endian (Intel)
+            if (signal.Intel())  // Little endian (Intel)
                 iVal = (RxMsg64 >> signal.StartBit) & bitMask;
             else                        // Big endian (Motorola)
                 iVal = (MirrorMsg(RxMsg64) >> GetStartBitLE(signal)) & bitMask;

--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -7,6 +7,7 @@ using uint32_T = System.UInt32;
 using int64_T = System.Int64;
 using uint64_T = System.UInt64;
 using System;
+using System.Runtime.InteropServices;
 using DbcParserLib.Model;
 
 namespace DbcParserLib
@@ -21,27 +22,34 @@ namespace DbcParserLib
         /// <returns>Returns a 64 bit unsigned data message</returns>
         public static uint64_T TxSignalPack(double value, Signal signal)
         {
-            int64_T iVal; 
+            int64_T iVal;
             uint64_T bitMask = signal.BitMask();
 
             // Apply scaling
-            iVal = (int64_T)Math.Round((value - signal.Offset) / signal.Factor);
-    
+            var rawValue = (value - signal.Offset) / signal.Factor;
+            if (signal.ValueType == DbcValueType.IEEEFloat)
+                iVal = (long)FloatConverter.AsInteger((float)rawValue);
+            else if(signal.ValueType == DbcValueType.IEEEDouble)
+                iVal = DoubleConverter.AsInteger(rawValue);
+            else
+                iVal = (int64_T)Math.Round(rawValue);
+
             // Apply overflow protection
             if (signal.ValueType == DbcValueType.Signed)
                 iVal = CLAMP(iVal, -(int64_T)(bitMask >> 1) - 1, (int64_T)(bitMask >> 1));
-            else
+            else if(signal.ValueType == DbcValueType.Unsigned)
                 iVal = CLAMP(iVal, 0L, (int64_T)bitMask);
 
             // Manage sign bit (if signed)
-            if (signal.ValueType == DbcValueType.Signed && iVal < 0) {
-              iVal += (int64_T)(1UL << signal.Length);
+            if (signal.ValueType == DbcValueType.Signed && iVal < 0)
+            {
+                iVal += (int64_T)(1UL << signal.Length);
             }
 
             // Pack signal
-            if (signal.Intel())  // Little endian (Intel)
+            if (signal.Intel()) // Little endian (Intel)
                 return (((uint64_T)iVal & bitMask) << signal.StartBit);
-            else                        // Big endian (Motorola)
+            else // Big endian (Motorola)
                 return MirrorMsg(((uint64_T)iVal & bitMask) << GetStartBitLE(signal));
         }
 
@@ -54,14 +62,14 @@ namespace DbcParserLib
         public static uint64_T TxStatePack(uint64_T value, Signal signal)
         {
             uint64_T bitMask = signal.BitMask();
-    
+
             // Apply overflow protection
             value = CLAMP(value, 0UL, bitMask);
-    
+
             // Pack signal
-            if (signal.Intel())  // Little endian (Intel)
+            if (signal.Intel()) // Little endian (Intel)
                 return ((value & bitMask) << signal.StartBit);
-            else                        // Big endian (Motorola)
+            else // Big endian (Motorola)
                 return MirrorMsg((value & bitMask) << GetStartBitLE(signal));
         }
 
@@ -73,18 +81,27 @@ namespace DbcParserLib
         /// <returns>Returns a double value representing the unpacked signal</returns>
         public static double RxSignalUnpack(uint64_T RxMsg64, Signal signal)
         {
-            int64_T iVal; 
+            int64_T iVal;
             uint64_T bitMask = signal.BitMask();
 
             // Unpack signal
-            if (signal.Intel())  // Little endian (Intel)
+            if (signal.Intel()) // Little endian (Intel)
                 iVal = (int64_T)((RxMsg64 >> signal.StartBit) & bitMask);
-            else                        // Big endian (Motorola)
+            else // Big endian (Motorola)
                 iVal = (int64_T)((MirrorMsg(RxMsg64) >> GetStartBitLE(signal)) & bitMask);
 
             // Manage sign bit (if signed)
-            if (signal.ValueType == DbcValueType.Signed) {
-              iVal -= ((iVal >> (signal.Length - 1)) != 0) ? (1L << signal.Length) : 0L;
+            if (signal.ValueType == DbcValueType.Signed)
+            {
+                iVal -= ((iVal >> (signal.Length - 1)) != 0) ? (1L << signal.Length) : 0L;
+            }
+            else if (signal.ValueType == DbcValueType.IEEEFloat)
+            {
+                return (FloatConverter.AsFloatingPoint((int)iVal) * signal.Factor + signal.Offset);
+            }
+            else if (signal.ValueType == DbcValueType.IEEEDouble)
+            {
+                return (DoubleConverter.AsFloatingPoint(iVal) * signal.Factor + signal.Offset);
             }
 
             // Apply scaling
@@ -99,19 +116,19 @@ namespace DbcParserLib
         /// <returns>Returns an unsigned integer representing the unpacked state</returns>
         public static uint64_T RxStateUnpack(uint64_T RxMsg64, Signal signal)
         {
-            uint64_T iVal; 
+            uint64_T iVal;
             uint64_T bitMask = signal.BitMask();
 
             // Unpack signal
-            if (signal.Intel())  // Little endian (Intel)
+            if (signal.Intel()) // Little endian (Intel)
                 iVal = (RxMsg64 >> signal.StartBit) & bitMask;
-            else                        // Big endian (Motorola)
+            else // Big endian (Motorola)
                 iVal = (MirrorMsg(RxMsg64) >> GetStartBitLE(signal)) & bitMask;
 
             // Apply scaling
             return iVal;
         }
-        
+
         private static int64_T CLAMP(int64_T x, int64_T low, int64_T high)
         {
             return Math.Max(low, Math.Min(x, high));
@@ -138,7 +155,7 @@ namespace DbcParserLib
                 (uint8_T)(msg >> 48),
                 (uint8_T)(msg >> 56)
             };
-            return   (((uint64_T)v[0] << 56)
+            return (((uint64_T)v[0] << 56)
                     | ((uint64_T)v[1] << 48)
                     | ((uint64_T)v[2] << 40)
                     | ((uint64_T)v[3] << 32)
@@ -155,6 +172,40 @@ namespace DbcParserLib
         {
             uint8_T startByte = (uint8_T)(signal.StartBit / 8);
             return (uint8_T)(64 - (signal.Length + 8 * startByte + (8 * (startByte + 1) - (signal.StartBit + 1)) % 8));
+        }
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class FloatConverter
+    {
+        [FieldOffset(0)] public int Integer;
+        [FieldOffset(0)] public float Float;
+
+        public static int AsInteger(float value)
+        {
+            return new FloatConverter() { Float = value }.Integer;
+        }
+
+        public static float AsFloatingPoint(int value)
+        {
+            return new FloatConverter() { Integer = value }.Float;
+        }
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public class DoubleConverter
+    {
+        [FieldOffset(0)] public long Integer;
+        [FieldOffset(0)] public double Float;
+
+        public static long AsInteger(double value)
+        {
+            return new DoubleConverter() { Float = value }.Integer;
+        }
+
+        public static double AsFloatingPoint(long value)
+        {
+            return new DoubleConverter() { Integer = value }.Float;
         }
     }
 }

--- a/DbcParserLib/Parser.cs
+++ b/DbcParserLib/Parser.cs
@@ -13,6 +13,7 @@ namespace DbcParserLib
             new MessageLineParser(),
             new CommentLineParser(),
             new SignalLineParser(),
+            new SignalValueTypeLineParser(),
             new ValueTableLineParser(),
             new PropertiesLineParser(),
             new UnknownLineParser() // Used as a catch all 

--- a/DbcParserLib/Parsers/SignalLineParser.cs
+++ b/DbcParserLib/Parsers/SignalLineParser.cs
@@ -19,18 +19,18 @@ namespace DbcParserLib.Parsers
 
         private readonly ParsingStrategy m_parsingStrategy;
 
-        public SignalLineParser() 
+        public SignalLineParser()
             : this(false)
         { }
 
-        public SignalLineParser(bool withRegex) 
+        public SignalLineParser(bool withRegex)
         {
             m_parsingStrategy = withRegex ? (ParsingStrategy)AddSignalRegex : AddSignal;
         }
 
         public bool TryParse(string line, IDbcBuilder builder)
         {
-            if(line.TrimStart().StartsWith(SignalLineStarter) == false)
+            if (line.TrimStart().StartsWith(SignalLineStarter) == false)
                 return false;
 
             m_parsingStrategy(line, builder);
@@ -59,20 +59,19 @@ namespace DbcParserLib.Parsers
                 sig.Multiplexing = records[2];
             }
 
-            sig.Name        = records[1];
-            sig.StartBit    = ushort.Parse(records[3 + muxOffset], CultureInfo.InvariantCulture);
-            sig.Length      = ushort.Parse(records[4 + muxOffset], CultureInfo.InvariantCulture);
-            sig.ByteOrder   = byte.Parse(records[5 + muxOffset].Substring(0, 1), CultureInfo.InvariantCulture);   // 0 = MSB (Motorola), 1 = LSB (Intel)
-            sig.IsSigned    = (byte)(records[5 + muxOffset][1] == '+' ? 0 : 1);
-            sig.ValueType   = (records[5 + muxOffset][1] == '+' ? DbcValueType.Unsigned : DbcValueType.Signed);
-            var factorStr   = records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0];
-            sig.IsInteger   = IsInteger(factorStr);
-            sig.Factor      = double.Parse(records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0], CultureInfo.InvariantCulture);
-            sig.Offset      = double.Parse(records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[1], CultureInfo.InvariantCulture);
-            sig.Minimum     = double.Parse(records[7 + muxOffset], CultureInfo.InvariantCulture);
-            sig.Maximum     = double.Parse(records[8 + muxOffset], CultureInfo.InvariantCulture);
-            sig.Unit        = records[9 + muxOffset].Split(new string[] { "\"" }, StringSplitOptions.None)[1];
-            sig.Receiver    = string.Join(Helpers.Space, records.Skip(10 + muxOffset)).Split(m_commaSpaceSeparator, StringSplitOptions.RemoveEmptyEntries);  // can be multiple receivers splitted by ","
+            sig.Name = records[1];
+            sig.StartBit = ushort.Parse(records[3 + muxOffset], CultureInfo.InvariantCulture);
+            sig.Length = ushort.Parse(records[4 + muxOffset], CultureInfo.InvariantCulture);
+            sig.ByteOrder = byte.Parse(records[5 + muxOffset].Substring(0, 1), CultureInfo.InvariantCulture);   // 0 = MSB (Motorola), 1 = LSB (Intel)
+            sig.ValueType = (records[5 + muxOffset][1] == '+' ? DbcValueType.Unsigned : DbcValueType.Signed);
+            var factorStr = records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0];
+            sig.IsInteger = IsInteger(factorStr);
+            sig.Factor = double.Parse(records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0], CultureInfo.InvariantCulture);
+            sig.Offset = double.Parse(records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[1], CultureInfo.InvariantCulture);
+            sig.Minimum = double.Parse(records[7 + muxOffset], CultureInfo.InvariantCulture);
+            sig.Maximum = double.Parse(records[8 + muxOffset], CultureInfo.InvariantCulture);
+            sig.Unit = records[9 + muxOffset].Split(new string[] { "\"" }, StringSplitOptions.None)[1];
+            sig.Receiver = string.Join(Helpers.Space, records.Skip(10 + muxOffset)).Split(m_commaSpaceSeparator, StringSplitOptions.RemoveEmptyEntries);  // can be multiple receivers splitted by ","
 
             builder.AddSignal(sig);
         }
@@ -97,7 +96,6 @@ namespace DbcParserLib.Parsers
                 StartBit = ushort.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture),
                 Length = ushort.Parse(match.Groups[4].Value, CultureInfo.InvariantCulture),
                 ByteOrder = byte.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture),   // 0 = MSB (Motorola), 1 = LSB (Intel)
-                IsSigned = (byte)(match.Groups[6].Value == SignedSymbol ? 1 : 0),
                 ValueType = (match.Groups[6].Value == SignedSymbol ? DbcValueType.Signed : DbcValueType.Unsigned),
                 IsInteger = IsInteger(factorStr),
                 Factor = double.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture),

--- a/DbcParserLib/Parsers/SignalLineParser.cs
+++ b/DbcParserLib/Parsers/SignalLineParser.cs
@@ -64,6 +64,7 @@ namespace DbcParserLib.Parsers
             sig.Length      = ushort.Parse(records[4 + muxOffset], CultureInfo.InvariantCulture);
             sig.ByteOrder   = byte.Parse(records[5 + muxOffset].Substring(0, 1), CultureInfo.InvariantCulture);   // 0 = MSB (Motorola), 1 = LSB (Intel)
             sig.IsSigned    = (byte)(records[5 + muxOffset][1] == '+' ? 0 : 1);
+            sig.ValueType   = (records[5 + muxOffset][1] == '+' ? DbcValueType.Unsigned : DbcValueType.Signed);
             var factorStr   = records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0];
             sig.IsInteger   = IsInteger(factorStr);
             sig.Factor      = double.Parse(records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0], CultureInfo.InvariantCulture);
@@ -97,6 +98,7 @@ namespace DbcParserLib.Parsers
                 Length = ushort.Parse(match.Groups[4].Value, CultureInfo.InvariantCulture),
                 ByteOrder = byte.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture),   // 0 = MSB (Motorola), 1 = LSB (Intel)
                 IsSigned = (byte)(match.Groups[6].Value == SignedSymbol ? 1 : 0),
+                ValueType = (match.Groups[6].Value == SignedSymbol ? DbcValueType.Signed : DbcValueType.Unsigned),
                 IsInteger = IsInteger(factorStr),
                 Factor = double.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture),
                 Offset = double.Parse(match.Groups[8].Value, CultureInfo.InvariantCulture),

--- a/DbcParserLib/Parsers/SignalValueTypeLineParser.cs
+++ b/DbcParserLib/Parsers/SignalValueTypeLineParser.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using DbcParserLib.Model;
+
+namespace DbcParserLib.Parsers
+{
+    public class SignalValueTypeLineParser : ILineParser
+    {
+        private const string SignalValueTypeStarter = "SIG_VALTYPE_ "; 
+
+        public bool TryParse(string line, IDbcBuilder builder)
+        {
+            var cleanLine = line.Trim(' ', ';');
+
+            if (cleanLine.StartsWith(SignalValueTypeStarter) == false)
+                return false;
+
+            string[] records = cleanLine.SplitBySpace();
+            if (records.Length > 3 && uint.TryParse(records[1], out var messageId) && byte.TryParse(records[3], out var valueType))
+            {
+                if (valueType == 1 || valueType == 2)
+                {
+                    builder.AddSignalValueType(messageId, records[2],
+                        valueType == 1 ? DbcValueType.IEEEFloat : DbcValueType.IEEEDouble);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This should add support for float and double types. I still believe we need some more unit tests in the pack/unpack part for both little and big endian