### PR TITLE
Fix lookup on Message Comments and Value Types when using Extended Frame

### DIFF
--- a/DbcParserLib/DbcBuilder.cs
+++ b/DbcParserLib/DbcBuilder.cs
@@ -43,6 +43,7 @@ namespace DbcParserLib
 
         public void AddSignalComment(uint messageId, string signalName, string comment)
         {
+            IsExtID(ref messageId);
             if (TryGetValueMessageSignal(messageId, signalName, out var signal))
             {
                 signal.Comment = comment;
@@ -60,6 +61,7 @@ namespace DbcParserLib
 
         public void AddSignalValueType(uint messageId, string signalName, DbcValueType valueType)
         {
+            IsExtID(ref messageId);
             if (TryGetValueMessageSignal(messageId, signalName, out var signal))
             {
                 signal.ValueType = valueType;
@@ -77,6 +79,7 @@ namespace DbcParserLib
 
         public void AddMessageComment(uint messageId, string comment)
         {
+            IsExtID(ref messageId);
             if (m_messages.TryGetValue(messageId, out var message))
             {
                 message.Comment = comment;


### PR DESCRIPTION
I am using your parser on extended frame (J1939) and it appears comments were not parsed.   This is an attempted fix.