### PR TITLE
#32  SignalLineParser now uses regex based parsing instead legacy spl…

### DIFF
--- a/DbcParserLib.Tests/ParserTests.cs
+++ b/DbcParserLib.Tests/ParserTests.cs
@@ -24,8 +24,8 @@ namespace DbcParserLib.Tests
         {
             var dbcString = @"
 BO_ 200 SENSOR: 39 SENSOR
- SG_ SENSOR__rear m1 : 256|6@1+ (0.1,0) [0|0] ""  DBG
- SG_ SENSOR__front m1 : 1755|1@1+ (0.1,0) [0|0] ""  DBG";
+ SG_ SENSOR__rear m1 : 256|6@1+ (0.1,0) [0|0] """"  DBG
+ SG_ SENSOR__front m1 : 1755|1@1+ (0.1,0) [0|0] """"  DBG";
 
 
             var dbc = Parser.Parse(dbcString);

--- a/DbcParserLib.Tests/SignalLineParserTests.cs
+++ b/DbcParserLib.Tests/SignalLineParserTests.cs
@@ -180,5 +180,21 @@ namespace DbcParserLib.Tests
 
             Assert.IsTrue(signalLineParser.TryParse(@" SG_ MCU_longitude m7 : 28|29@1- (1E-006,0) [-10|35.6] ""deg""  NEO, WHEEL, TOP", dbcBuilderMock.Object, nextLineProviderMock.Object));
         }
+
+        [Test]
+        public void ParseSignalWithDifferentColonSpaces()
+        {
+            var dbcString = @"
+BO_ 200 SENSOR: 39 SENSOR
+ SG_ SENSOR__rear m1: 256|6@1+ (0.1,0) [0|0] """"  DBG
+ SG_ SENSOR__front m1 :1755|1@1+ (0.1,0) [0|0] """"  DBG
+ SG_ MCU_longitude m7:28|29@1- (1E-006,0) [-10|35.6] ""deg""  NEO";
+
+
+            var dbc = Parser.Parse(dbcString);
+
+            Assert.AreEqual(1, dbc.Messages.Count());
+            Assert.AreEqual(3, dbc.Messages.SelectMany(m => m.Signals).Count());
+        }
     }
 }

--- a/DbcParserLib/Parsers/SignalLineParser.cs
+++ b/DbcParserLib/Parsers/SignalLineParser.cs
@@ -20,40 +20,36 @@ namespace DbcParserLib.Parsers
             if (line.TrimStart().StartsWith(SignalLineStarter) == false)
                 return false;
 
-            AddSignal(line, builder);
+            var match = Regex.Match(line, SignalRegex);
+            if (match.Success)
+            {
+                var factorStr = match.Groups[7].Value;
+                var sig = new Signal
+                {
+                    Multiplexing = match.Groups[2].Value,
+                    Name = match.Groups[1].Value,
+                    StartBit = ushort.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture),
+                    Length = ushort.Parse(match.Groups[4].Value, CultureInfo.InvariantCulture),
+                    ByteOrder = byte.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture),   // 0 = MSB (Motorola), 1 = LSB (Intel)
+                    ValueType = (match.Groups[6].Value == SignedSymbol ? DbcValueType.Signed : DbcValueType.Unsigned),
+                    IsInteger = IsInteger(factorStr),
+                    Factor = double.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture),
+                    Offset = double.Parse(match.Groups[8].Value, CultureInfo.InvariantCulture),
+                    Minimum = double.Parse(match.Groups[9].Value, CultureInfo.InvariantCulture),
+                    Maximum = double.Parse(match.Groups[10].Value, CultureInfo.InvariantCulture),
+                    Unit = match.Groups[11].Value,
+                    Receiver = match.Groups[12].Value.Split(m_commaSpaceSeparator, StringSplitOptions.RemoveEmptyEntries)  // can be multiple receivers splitted by ","
+                };
+
+                builder.AddSignal(sig);
+            }
+
             return true;
         }
 
         private static bool IsInteger(string str)
         {
             return int.TryParse(str, out _);
-        }
-
-        private static void AddSignal(string line, IDbcBuilder builder)
-        {
-            var match = Regex.Match(line, SignalRegex);
-
-            if (match.Success == false)
-                return;
-            var factorStr = match.Groups[7].Value;
-            var sig = new Signal
-            {
-                Multiplexing = match.Groups[2].Value,
-                Name = match.Groups[1].Value,
-                StartBit = ushort.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture),
-                Length = ushort.Parse(match.Groups[4].Value, CultureInfo.InvariantCulture),
-                ByteOrder = byte.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture),   // 0 = MSB (Motorola), 1 = LSB (Intel)
-                ValueType = (match.Groups[6].Value == SignedSymbol ? DbcValueType.Signed : DbcValueType.Unsigned),
-                IsInteger = IsInteger(factorStr),
-                Factor = double.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture),
-                Offset = double.Parse(match.Groups[8].Value, CultureInfo.InvariantCulture),
-                Minimum = double.Parse(match.Groups[9].Value, CultureInfo.InvariantCulture),
-                Maximum = double.Parse(match.Groups[10].Value, CultureInfo.InvariantCulture),
-                Unit = match.Groups[11].Value,
-                Receiver = match.Groups[12].Value.Split(m_commaSpaceSeparator, StringSplitOptions.RemoveEmptyEntries)  // can be multiple receivers splitted by ","
-            };
-
-            builder.AddSignal(sig);
         }
     }
 }

--- a/DbcParserLib/Parsers/SignalLineParser.cs
+++ b/DbcParserLib/Parsers/SignalLineParser.cs
@@ -12,28 +12,15 @@ namespace DbcParserLib.Parsers
 
         private const string SignalLineStarter = "SG_";
         private const string SignedSymbol = "-";
-        private static readonly string[] m_commaSeparator = new string[] { Helpers.Comma };
         private static readonly string[] m_commaSpaceSeparator = new string[] { Helpers.Space, Helpers.Comma };
-        private static readonly string[] m_signalLineSplittingItems = new string[] { Helpers.Space, "|", "@", "(", ")", "[", "|", "]" };
         private const string SignalRegex = @"\s*SG_\s+([\w]+)\s*([Mm\d]*)\s*:\s*(\d+)\|(\d+)@([01])([+-])\s+\(([\d\+\-eE.]+),([\d\+\-eE.]+)\)\s+\[([\d\+\-eE.]+)\|([\d\+\-eE.]+)\]\s+""(.*)""\s+([\w\s,]+)";
                                            
-        private readonly ParsingStrategy m_parsingStrategy;
-
-        public SignalLineParser()
-            : this(false)
-        { }
-
-        public SignalLineParser(bool withRegex)
-        {
-            m_parsingStrategy = withRegex ? (ParsingStrategy)AddSignalRegex : AddSignal;
-        }
-
         public bool TryParse(string line, IDbcBuilder builder, INextLineProvider nextLineProvider)
         {
             if (line.TrimStart().StartsWith(SignalLineStarter) == false)
                 return false;
 
-            m_parsingStrategy(line, builder);
+            AddSignal(line, builder);
             return true;
         }
 
@@ -43,46 +30,6 @@ namespace DbcParserLib.Parsers
         }
 
         private static void AddSignal(string line, IDbcBuilder builder)
-        {
-            int muxOffset = 0;
-            var records = line
-                .TrimStart()
-                .Split(m_signalLineSplittingItems, StringSplitOptions.RemoveEmptyEntries);
-
-            if (records.Length < 10)
-                return;
-
-            var sig = new Signal();
-            if (records[2] != ":")    // signal is multiplexed
-            {
-                muxOffset = 1;
-                sig.Multiplexing = records[2];
-            }
-
-            sig.Name = records[1];
-            sig.StartBit = ushort.Parse(records[3 + muxOffset], CultureInfo.InvariantCulture);
-            sig.Length = ushort.Parse(records[4 + muxOffset], CultureInfo.InvariantCulture);
-            sig.ByteOrder = byte.Parse(records[5 + muxOffset].Substring(0, 1), CultureInfo.InvariantCulture);   // 0 = MSB (Motorola), 1 = LSB (Intel)
-            sig.ValueType = (records[5 + muxOffset][1] == '+' ? DbcValueType.Unsigned : DbcValueType.Signed);
-            var factorStr = records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0];
-            sig.IsInteger = IsInteger(factorStr);
-            sig.Factor = double.Parse(records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[0], CultureInfo.InvariantCulture);
-            sig.Offset = double.Parse(records[6 + muxOffset].Split(m_commaSeparator, StringSplitOptions.None)[1], CultureInfo.InvariantCulture);
-            sig.Minimum = double.Parse(records[7 + muxOffset], CultureInfo.InvariantCulture);
-            sig.Maximum = double.Parse(records[8 + muxOffset], CultureInfo.InvariantCulture);
-            sig.Unit = records[9 + muxOffset].Split(new string[] { "\"" }, StringSplitOptions.None)[1];
-            sig.Receiver = string.Join(Helpers.Space, records.Skip(10 + muxOffset)).Split(m_commaSpaceSeparator, StringSplitOptions.RemoveEmptyEntries);  // can be multiple receivers splitted by ","
-
-            builder.AddSignal(sig);
-        }
-
-        /// <summary>
-        /// This method parses using Regex instead of string split. Beside benchmarking (which may not be the main reason), 
-        /// I find that this allows much better control over syntax, create way less arrays and strings, is more robust over spaces etc
-        /// </summary>
-        /// <param name="line">The line to be parsed</param>
-        /// <param name="builder">The dbc builder to be used</param>
-        private static void AddSignalRegex(string line, IDbcBuilder builder)
         {
             var match = Regex.Match(line, SignalRegex);
 


### PR DESCRIPTION
…it based one

SingalLineParser now uses regex parsing instead string split. Added test for colon space for signal parsing