### PR TITLE
Correct floating point error with RxSignalUnpack

### DIFF
--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -105,7 +105,7 @@ namespace DbcParserLib
             }
 
             // Apply scaling
-            return ((double)iVal * signal.Factor + signal.Offset);
+            return ((double)(iVal * (decimal)signal.Factor + (decimal)signal.Offset));
         }
 
         /// <summary>


### PR DESCRIPTION
Edit output of RxSignalUnpack to account for Floating-Point Precision which fixes issue #39 