### PR TITLE
#41 Fixed enum definition parser repeating last value twice

### DIFF
--- a/DbcParserLib.Tests/PropertiesLineParserTests.cs
+++ b/DbcParserLib.Tests/PropertiesLineParserTests.cs
@@ -99,23 +99,59 @@ namespace DbcParserLib.Tests
         [Test]
         public void EnumDefinitionCustomPropertyIsParsedTest()
         {
-            var builder = new DbcBuilder(new SilentFailureObserver());
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+
+            dbcBuilderMock.Setup(mock => mock.AddCustomProperty(It.IsAny<CustomPropertyObjectType>(), It.IsAny<CustomPropertyDefinition>()))
+                .Callback<CustomPropertyObjectType, CustomPropertyDefinition>((objectType, customProperty) =>
+                {
+                    Assert.AreEqual("AttributeName", customProperty.Name);
+                    Assert.AreEqual(CustomPropertyDataType.Enum, customProperty.DataType);
+                    Assert.AreEqual(3, customProperty.EnumCustomProperty.Values.Length);
+                    Assert.AreEqual("Val1", customProperty.EnumCustomProperty.Values[0]);
+                    Assert.AreEqual("Val2", customProperty.EnumCustomProperty.Values[1]);
+                    Assert.AreEqual("Val3", customProperty.EnumCustomProperty.Values[2]);
+                });
+
+            dbcBuilderMock.Setup(mock => mock.AddCustomPropertyDefaultValue(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string>((propertyName, value) =>
+                {
+                    Assert.AreEqual("AttributeName", propertyName);
+                    Assert.AreEqual("Val2", value);
+                });
 
             var customPropertyLineParsers = CreateParser();
-            var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
-            Assert.IsTrue(ParseLine(@"BA_DEF_ BU_ ""AttributeName"" ENUM ""Val1"",""Val2"",""Val3"";", customPropertyLineParsers, builder, nextLineProvider));
-            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" ""Val2"";", customPropertyLineParsers, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_DEF_ BU_ ""AttributeName"" ENUM ""Val1"",""Val2"",""Val3"";", customPropertyLineParsers, dbcBuilderMock.Object, nextLineProviderMock.Object));
+            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" ""Val2"";", customPropertyLineParsers, dbcBuilderMock.Object, nextLineProviderMock.Object));
         }
 
         [Test]
         public void EnumDefinitionCustomPropertyMoreWhiteSpaceIsParsedTest()
         {
-            var builder = new DbcBuilder(new SilentFailureObserver());
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+
+            dbcBuilderMock.Setup(mock => mock.AddCustomProperty(It.IsAny<CustomPropertyObjectType>(), It.IsAny<CustomPropertyDefinition>()))
+                .Callback<CustomPropertyObjectType, CustomPropertyDefinition>((_, customProperty) =>
+                {
+                    Assert.AreEqual("AttributeName", customProperty.Name);
+                    Assert.AreEqual(CustomPropertyDataType.Enum, customProperty.DataType);
+                    Assert.AreEqual(3, customProperty.EnumCustomProperty.Values.Length);
+                    Assert.AreEqual("Val1", customProperty.EnumCustomProperty.Values[0]);
+                    Assert.AreEqual("Val2", customProperty.EnumCustomProperty.Values[1]);
+                    Assert.AreEqual("Val3", customProperty.EnumCustomProperty.Values[2]);
+                });
+
+            dbcBuilderMock.Setup(mock => mock.AddCustomPropertyDefaultValue(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string>((propertyName, value) =>
+                {
+                    Assert.AreEqual("AttributeName", propertyName);
+                    Assert.AreEqual("Val2", value);
+                });
 
             var customPropertyLineParsers = CreateParser();
-            var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
-            Assert.IsTrue(ParseLine(@"BA_DEF_ BU_ ""AttributeName"" ENUM   ""Val1"",""Val2"",""Val3"" ;", customPropertyLineParsers, builder, nextLineProvider));
-            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" ""Val2"";", customPropertyLineParsers, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_DEF_ BU_ ""AttributeName"" ENUM   ""Val1"",""Val2"",""Val3"" ;", customPropertyLineParsers, dbcBuilderMock.Object, nextLineProviderMock.Object));
+            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" ""Val2"";", customPropertyLineParsers, dbcBuilderMock.Object, nextLineProviderMock.Object));
         }
 
         [Test]

--- a/DbcParserLib/Parsers/PropertiesDefinitionLineParser.cs
+++ b/DbcParserLib/Parsers/PropertiesDefinitionLineParser.cs
@@ -9,7 +9,9 @@ namespace DbcParserLib.Parsers
     {
         private const string PropertiesDefinitionLineStarter = "BA_DEF_ ";
         private const string PropertiesDefinitionDefaultLineStarter = "BA_DEF_DEF_ ";
-        private const string PropertyDefinitionParsingRegex = @"BA_DEF_(?:\s+(BU_|BO_|SG_|EV_))?\s+""([a-zA-Z_][\w]*)""\s+(?:(?:(INT|HEX)\s+(-?\d+)\s+(-?\d+))|(?:(FLOAT)\s+([\d\+\-eE.]+)\s+([\d\+\-eE.]+))|(STRING)|(?:(ENUM)\s+((?:""[^""]*"",+)*(""[^""]*""))))\s*;";
+        // language=regex
+        private const string PropertyDefinitionParsingRegex = @"BA_DEF_(?:\s+(BU_|BO_|SG_|EV_))?\s+""([a-zA-Z_][\w]*)""\s+(?:(?:(INT|HEX)\s+(-?\d+)\s+(-?\d+))|(?:(FLOAT)\s+([\d\+\-eE.]+)\s+([\d\+\-eE.]+))|(STRING)|(?:(ENUM)\s+((?:""[^""]*"",+)*(?:""[^""]*""))))\s*;";
+        // language=regex
         private const string PropertyDefinitionDefaultParsingRegex = @"BA_DEF_DEF_\s+""([a-zA-Z_][\w]*)""\s+(-?\d+|[\d\+\-eE.]+|""[^""]*"")\s*;";
 
         private readonly IParseFailureObserver m_observer;
@@ -93,10 +95,9 @@ namespace DbcParserLib.Parsers
                     else if (match.Groups[10].Value.StartsWith("ENUM"))
                     {
                         dataType = CustomPropertyDataType.Enum;
-                        var enumDefinition = match.Groups[11].Value + match.Groups[12].Value;
                         customProperty.EnumCustomProperty = new EnumCustomPropertyDefinition
                         {
-                            Values = enumDefinition.Replace("\"", "").Split(',')
+                            Values = match.Groups[11].Value.Replace("\"", "").Split(',')
                         };
                     }
                     customProperty.DataType = dataType;


### PR DESCRIPTION
The regex to parse enum definition values got broken by a change related to #41. It had two nested capture groups which led to the last value beeing repeated twice. Fixed the regex and updated the test code to check for the correct values.