### PR TITLE
#47 Fixed enum assignment by index

### DIFF
--- a/DbcParserLib.Tests/PropertiesLineParserTests.cs
+++ b/DbcParserLib.Tests/PropertiesLineParserTests.cs
@@ -136,6 +136,23 @@ namespace DbcParserLib.Tests
         }
 
         [Test]
+        public void MsgCustomPropertyEnumIndexedValueIsParsedTest()
+        {
+            var builder = new DbcBuilder(new SilentFailureObserver());
+            var message = new Message { ID = 2394947585 };
+            builder.AddMessage(message);
+
+            var customPropertyLineParsers = CreateParser();
+            var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
+            Assert.IsTrue(ParseLine(@"BA_DEF_ BO_ ""AttributeName"" ENUM ""Val1"",""Val2"",""Val3"";", customPropertyLineParsers, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" ""Val1"";", customPropertyLineParsers, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_ ""AttributeName"" BO_ 2394947585 1;", customPropertyLineParsers, builder, nextLineProvider));
+
+            var dbc = builder.Build();
+            Assert.AreEqual("Val2", dbc.Messages.First().CustomProperties["AttributeName"].EnumCustomProperty.Value);
+        }
+
+        [Test]
         public void SigCustomPropertyIsParsedTest()
         {
             var builder = new DbcBuilder(new SilentFailureObserver());

--- a/DbcParserLib/Model/CustomProperty.cs
+++ b/DbcParserLib/Model/CustomProperty.cs
@@ -23,31 +23,31 @@ namespace DbcParserLib.Model
                 case CustomPropertyDataType.Integer:
                     IntegerCustomProperty = new CustomPropertyValue<int>()
                     {
-                        Value = int.Parse(value, CultureInfo.InvariantCulture)
+                        Value = int.Parse(value.Replace("\"", ""), CultureInfo.InvariantCulture)
                     };
                     break;
                 case CustomPropertyDataType.Hex:
                     HexCustomProperty = new CustomPropertyValue<int>()
                     {
-                        Value = int.Parse(value, CultureInfo.InvariantCulture)
+                        Value = int.Parse(value.Replace("\"", ""), CultureInfo.InvariantCulture)
                     };
                     break;
                 case CustomPropertyDataType.Float:
                     FloatCustomProperty = new CustomPropertyValue<double>()
                     {
-                        Value = float.Parse(value, CultureInfo.InvariantCulture)
+                        Value = float.Parse(value.Replace("\"", ""), CultureInfo.InvariantCulture)
                     };
                     break;
                 case CustomPropertyDataType.String:
                     StringCustomProperty = new CustomPropertyValue<string>()
                     {
-                        Value = value
+                        Value = value.Replace("\"", "")
                     };
                     break;
                 case CustomPropertyDataType.Enum:
                     EnumCustomProperty = new CustomPropertyValue<string>()
                     {
-                        Value = value
+                        Value = CustomPropertyDefinition.TryGetEnumValue(value, out var enumValue) ? enumValue : value.Replace("\"", "")
                     };
                     break;
             }

--- a/DbcParserLib/Model/CustomPropertyDefinition.cs
+++ b/DbcParserLib/Model/CustomPropertyDefinition.cs
@@ -17,21 +17,42 @@ namespace DbcParserLib.Model
             switch (DataType)
             {
                 case CustomPropertyDataType.Integer:
-                    IntegerCustomProperty.Default = int.Parse(value, CultureInfo.InvariantCulture);
+                    IntegerCustomProperty.Default = int.Parse(value.Replace("\"", ""), CultureInfo.InvariantCulture);
                     break;
                 case CustomPropertyDataType.Hex:
-                    HexCustomProperty.Default = int.Parse(value, CultureInfo.InvariantCulture);
+                    HexCustomProperty.Default = int.Parse(value.Replace("\"", ""), CultureInfo.InvariantCulture);
                     break;
                 case CustomPropertyDataType.Float:
-                    FloatCustomProperty.Default = float.Parse(value, CultureInfo.InvariantCulture);
+                    FloatCustomProperty.Default = float.Parse(value.Replace("\"", ""), CultureInfo.InvariantCulture);
                     break;
                 case CustomPropertyDataType.String:
-                    StringCustomProperty.Default = value;
+                    StringCustomProperty.Default = value.Replace("\"", "");
                     break;
                 case CustomPropertyDataType.Enum:
-                    EnumCustomProperty.Default = value;
+                    EnumCustomProperty.Default = TryGetEnumValue(value, out var enumValue) ? enumValue : value.Replace("\"", "");
                     break;
             }
+        }
+
+        internal bool TryGetEnumValue(string value, out string enumValue)
+        {
+            enumValue = null;
+
+            if (value.Contains("\""))
+                return false;
+
+            if (EnumCustomProperty == null)
+                return false;
+
+            if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index))
+                return false;
+
+            if (index < 0 || index >= EnumCustomProperty.Values.Length)
+                return false;
+
+            enumValue = EnumCustomProperty.Values[index];
+
+            return true;
         }
     }
 

--- a/DbcParserLib/Parsers/PropertiesDefinitionLineParser.cs
+++ b/DbcParserLib/Parsers/PropertiesDefinitionLineParser.cs
@@ -31,7 +31,7 @@ namespace DbcParserLib.Parsers
             {
                 var match = Regex.Match(cleanLine, PropertyDefinitionDefaultParsingRegex);
                 if (match.Success)
-                    builder.AddCustomPropertyDefaultValue(match.Groups[1].Value, match.Groups[2].Value.Replace("\"", ""));
+                    builder.AddCustomPropertyDefaultValue(match.Groups[1].Value, match.Groups[2].Value);
                 else
                     m_observer.PropertyDefaultSyntaxError();
                 return true;

--- a/DbcParserLib/Parsers/PropertiesLineParser.cs
+++ b/DbcParserLib/Parsers/PropertiesLineParser.cs
@@ -27,18 +27,18 @@ namespace DbcParserLib.Parsers
             if (match.Success)
             {
                 if (match.Groups[2].Value == "BU_")
-                    builder.AddNodeCustomProperty(match.Groups[1].Value, match.Groups[3].Value, match.Groups[9].Value.Replace("\"", ""));
+                    builder.AddNodeCustomProperty(match.Groups[1].Value, match.Groups[3].Value, match.Groups[9].Value);
                 else if (match.Groups[2].Value == "EV_")
-                    builder.AddEnvironmentVariableCustomProperty(match.Groups[1].Value, match.Groups[3].Value, match.Groups[9].Value.Replace("\"", ""));
+                    builder.AddEnvironmentVariableCustomProperty(match.Groups[1].Value, match.Groups[3].Value, match.Groups[9].Value);
                 else if (match.Groups[4].Value == "BO_")
                 {
-                    builder.AddMessageCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture), match.Groups[9].Value.Replace("\"", ""));
+                    builder.AddMessageCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture), match.Groups[9].Value);
                     if (match.Groups[1].Value == "GenMsgCycleTime")
                         builder.AddMessageCycleTime(uint.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture), int.Parse(match.Groups[9].Value, CultureInfo.InvariantCulture));
                 }
                 else if (match.Groups[6].Value == "SG_")
                 {
-                    builder.AddSignalCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture), match.Groups[8].Value, match.Groups[9].Value.Replace("\"", ""));
+                    builder.AddSignalCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture), match.Groups[8].Value, match.Groups[9].Value);
                     if (match.Groups[1].Value == "GenSigStartValue")
                         builder.AddSignalInitialValue(uint.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture), match.Groups[8].Value, double.Parse(match.Groups[9].Value, CultureInfo.InvariantCulture));
                 }


### PR DESCRIPTION
It seems like dbc files reference the enum value by index. Changed the parser logic to pass the quoted strings to handle both cases correctly and added an additional test.

Fixes #47