### PR TITLE
#47 Custom properties parsing failures management

### DIFF
--- a/DbcParserLib.Tests/MessageLineParserTests.cs
+++ b/DbcParserLib.Tests/MessageLineParserTests.cs
@@ -132,7 +132,7 @@ namespace DbcParserLib.Tests
             var nextLineProviderMock = m_repository.Create<INextLineProvider>();
             var dbcBuilder = new DbcBuilder(observerMock.Object);
 
-            observerMock.Setup(o => o.DuplicateMessage(messageId));
+            observerMock.Setup(o => o.DuplicatedMessage(messageId));
 
             var lineParser = new MessageLineParser(observerMock.Object);
             lineParser.TryParse(line, dbcBuilder, nextLineProviderMock.Object);

--- a/DbcParserLib.Tests/NodeLineParserTests.cs
+++ b/DbcParserLib.Tests/NodeLineParserTests.cs
@@ -117,7 +117,7 @@ namespace DbcParserLib.Tests
             var nextLineProviderMock = m_repository.Create<INextLineProvider>();
             var dbcBuilder = new DbcBuilder(observerMock.Object);
         
-            observerMock.Setup(o => o.DuplicateNode(nodeName));
+            observerMock.Setup(o => o.DuplicatedNode(nodeName));
         
             var lineParser = new NodeLineParser(observerMock.Object);
             lineParser.TryParse(line, dbcBuilder, nextLineProviderMock.Object);

--- a/DbcParserLib.Tests/PropertiesDefaultParsingFailuresTests.cs
+++ b/DbcParserLib.Tests/PropertiesDefaultParsingFailuresTests.cs
@@ -1,0 +1,262 @@
+﻿using NUnit.Framework;
+using DbcParserLib.Parsers;
+using Moq;
+using System.Linq;
+using DbcParserLib.Observers;
+
+namespace DbcParserLib.Tests
+{
+    public class PropertiesDefaultParsingFailuresTests
+    {
+        private MockRepository m_repository;
+
+        [SetUp]
+        public void Setup()
+        {
+            m_repository = new MockRepository(MockBehavior.Strict);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            m_repository.VerifyAll();
+        }
+
+        private void ParseLine(string line1, string line2, IParseFailureObserver observer)
+        {
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+            var dbcBuilder = new DbcBuilder(observer);
+
+            var lineParser = new PropertiesDefinitionLineParser(observer);
+            lineParser.TryParse(line1, dbcBuilder, nextLineProviderMock.Object);
+            lineParser.TryParse(line2, dbcBuilder, nextLineProviderMock.Object);
+        }
+
+        [TestCase("BA_DEF_DEF_ \"attributeName\" BO_ -123 100;")]
+        [TestCase("BA_DEF_DEF_ \"attributeName\" SG_ 123 signalName value")]
+        [TestCase("BA_DEF_DEF_ \"attributeName\" EV_ 0varName 1e10;")]
+        [TestCase("BA_DEF_DEF_ attributeName BU_ nodeName 0;")]
+        public void PropertyDefaultSyntaxErrorIsObserved(string line)
+        {
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+
+            observerMock.Setup(o => o.PropertyDefaultSyntaxError());
+
+            var lineParser = new PropertiesDefinitionLineParser(observerMock.Object);
+            lineParser.TryParse(line, dbcBuilderMock.Object, nextLineProviderMock.Object);
+        }
+
+        [Test]
+        public void CustomPropertyDefaultNotFoundErrorIsObserved()
+        {
+            var propertyName = "attributeName";
+            var line = $"BA_DEF_DEF_ \"{propertyName}\" 0;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+            var dbcBuilder = new DbcBuilder(observerMock.Object);
+
+            observerMock.Setup(o => o.PropertyNameNotFound(propertyName));
+
+            var lineParser = new PropertiesDefinitionLineParser(observerMock.Object);
+            lineParser.TryParse(line, dbcBuilder, nextLineProviderMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyIntegerWithStringValueErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" INT 0 100;";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" \"50\";";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyHexWithStringValueErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" HEX 0 100;";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" \"50\";";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyFloatWithStringValueErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" FLOAT 0 100;";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" \"50\";";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyIntegerOutOfBoundErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" INT 0 100;";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" 110;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "110"));
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyHexOutOfBoundErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" HEX 0 100;";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" 110;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "110"));
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyFloatOutOfBoundErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" FLOAT 0 10;";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" 20;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "20"));
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyIntegerNotIntegerValueErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" INT 0 100;";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" 1.5;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyHexNotIntegerValueErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" HEX 0 100;";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" 1.5;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyStringNotStringValueErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" STRING;";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" 10;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumNotIntegerIndexValueErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" ENUM \"FirstVal\",\"SecondVal\",\"ThirdVal\";";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" 1.5;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumOutOfIndexValueErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" ENUM \"FirstVal\",\"SecondVal\",\"ThirdVal\";";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" 3;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfIndex(propertyName, "3"));
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumOutOfBoundValueErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" ENUM \"FirstVal\",\"SecondVal\",\"ThirdVal\";";
+            var line2 = $"BA_DEF_DEF_ \"{propertyName}\" \"3\";";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "3"));
+            ParseLine(line1, line2, observerMock.Object);
+
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumWithIntegerValuesIsParsed()
+        {
+            var dbcString = @"
+BO_ 200 SENSOR: 39 SENSOR
+ BA_DEF_ BO_ ""AttributeName"" ENUM ""1"",""2"",""3"";
+ BA_DEF_DEF_ ""AttributeName"" ""3"";";
+
+            var dbc = Parser.Parse(dbcString);
+
+            Assert.AreEqual(1, dbc.Messages.Count());
+            Assert.AreEqual("3", dbc.Messages.First().CustomProperties.Values.First().EnumCustomProperty.Value);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumWithIntegerValuesByIndexIsParsed()
+        {
+            var dbcString = @"
+BO_ 200 SENSOR: 39 SENSOR
+ BA_DEF_ BO_ ""AttributeName"" ENUM ""1"",""2"",""3"";
+ BA_DEF_DEF_ ""AttributeName"" 2;";
+
+            var dbc = Parser.Parse(dbcString);
+
+            Assert.AreEqual(1, dbc.Messages.Count());
+            Assert.AreEqual("3", dbc.Messages.First().CustomProperties.Values.First().EnumCustomProperty.Value);
+        }
+    }
+}

--- a/DbcParserLib.Tests/PropertiesDefaultParsingFailuresTests.cs
+++ b/DbcParserLib.Tests/PropertiesDefaultParsingFailuresTests.cs
@@ -102,7 +102,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertySyntaxError());
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]
@@ -116,7 +115,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "110"));
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]
@@ -130,7 +128,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "110"));
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]
@@ -144,7 +141,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "20"));
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]
@@ -158,7 +154,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertySyntaxError());
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]
@@ -172,7 +167,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertySyntaxError());
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]
@@ -186,7 +180,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertySyntaxError());
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]
@@ -200,7 +193,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertySyntaxError());
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]
@@ -214,7 +206,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertyValueOutOfIndex(propertyName, "3"));
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]
@@ -228,7 +219,6 @@ namespace DbcParserLib.Tests
 
             observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "3"));
             ParseLine(line1, line2, observerMock.Object);
-
         }
 
         [Test]

--- a/DbcParserLib.Tests/PropertiesParsingFailuresTests.cs
+++ b/DbcParserLib.Tests/PropertiesParsingFailuresTests.cs
@@ -1,0 +1,359 @@
+﻿using NUnit.Framework;
+using DbcParserLib.Parsers;
+using DbcParserLib.Model;
+using Moq;
+using System.Linq;
+using DbcParserLib.Observers;
+
+namespace DbcParserLib.Tests
+{
+    public class PropertiesParsingFailuresTests
+    {
+        private MockRepository m_repository;
+
+        [SetUp]
+        public void Setup()
+        {
+            m_repository = new MockRepository(MockBehavior.Strict);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            m_repository.VerifyAll();
+        }
+
+        private void ParseLine(string line1, string line2, uint messageId, IParseFailureObserver observer)
+        {
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+            var dbcBuilder = new DbcBuilder(observer);
+            dbcBuilder.AddMessage(new Message()
+            {
+                ID = messageId
+            });
+
+            var definitionLineParser = new PropertiesDefinitionLineParser(observer);
+            var lineParser = new PropertiesLineParser(observer);
+            definitionLineParser.TryParse(line1, dbcBuilder, nextLineProviderMock.Object);
+            lineParser.TryParse(line2, dbcBuilder, nextLineProviderMock.Object);
+        }
+
+        [TestCase("BA_ \"attributeName\" BO_ -123 100;")]
+        [TestCase("BA_ \"attributeName\" SG_ 123 signalName value;")]
+        [TestCase("BA_ \"attributeName\" EV_ varName 1e10")]
+        [TestCase("BA_ attributeName BU_ nodeName 0;")]
+        public void PropertySyntaxErrorIsObserved(string line)
+        {
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+
+            var lineParser = new PropertiesLineParser(observerMock.Object);
+            lineParser.TryParse(line, dbcBuilderMock.Object, nextLineProviderMock.Object);
+        }
+
+        [Test]
+        public void CustomPropertyNotFoundErrorIsObserved()
+        {
+            var propertyName = "attributeName";
+            var nodeName = "nodeName";
+            var value = "100";
+            var line = $"BA_ \"{propertyName}\" BU_ {nodeName} {value};";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+            var dbcBuilder = new DbcBuilder(observerMock.Object);
+
+            observerMock.Setup(o => o.PropertyNameNotFound(propertyName));
+
+            var lineParser = new PropertiesLineParser(observerMock.Object);
+            lineParser.TryParse(line, dbcBuilder, nextLineProviderMock.Object);
+        }
+
+        [Test]
+        public void CustomPropertyNodeNotFoundErrorIsObserved()
+        {
+            var propertyName = "attributeName";
+            var nodeName = "nodeName";
+            var value = "100";
+
+            var line1 = $"BA_DEF_ BU_ \"{propertyName}\" INT 0 65535;";
+            var line2 = $"BA_ \"{propertyName}\" BU_ {nodeName} {value};";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+            var dbcBuilder = new DbcBuilder(observerMock.Object);
+
+            observerMock.Setup(o => o.NodeNameNotFound(nodeName));
+
+            ILineParser lineParser = new PropertiesDefinitionLineParser(observerMock.Object);
+            lineParser.TryParse(line1, dbcBuilder, nextLineProviderMock.Object);
+            
+            lineParser = new PropertiesLineParser(observerMock.Object);
+            lineParser.TryParse(line2, dbcBuilder, nextLineProviderMock.Object);
+        }
+
+        [Test]
+        public void DuplicateCustomPropertyErrorIsObserved()
+        {
+            var propertyName = "attributeName";
+            var nodeName = "nodeName";
+            var value = "100";
+
+            var line1 = $"BA_DEF_ BU_ \"{propertyName}\" INT 0 65535;";
+            var line2 = $"BA_ \"{propertyName}\" BU_ {nodeName} {value};";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+            var dbcBuilder = new DbcBuilder(observerMock.Object);
+
+            observerMock.Setup(o => o.DuplicatedPropertyInNode(propertyName, nodeName));
+
+            dbcBuilder.AddNode(new Node()
+            {
+                Name = nodeName
+            });
+            ILineParser lineParser = new PropertiesDefinitionLineParser(observerMock.Object);
+            lineParser.TryParse(line1, dbcBuilder, nextLineProviderMock.Object);
+            
+            lineParser = new PropertiesLineParser(observerMock.Object);
+            lineParser.TryParse(line2, dbcBuilder, nextLineProviderMock.Object);
+            lineParser.TryParse(line2, dbcBuilder, nextLineProviderMock.Object);
+        }
+
+        [TestCase("BA_DEF_ BO_ \"GenMsgCycleTime\" INT 1.5 65535;")]
+        [TestCase("BA_DEF_ \"attributeName\" STRING")]
+        [TestCase("BA_DEF_ SGG_ \"attributeName\" FLOAT -3.4E+038 3.4E+038;")]
+        [TestCase("BA_DEF_ BU_ \"attributeName\" STRING 0;")]
+        [TestCase("BA_DEF_ attributeName STRING")]
+        [TestCase("BA_DEF_ BU_ \"Ciao\" ENUM  \"Cyclic\"\"Event\",\"CyclicIfActive\",\"SpontanWithDelay\",\"CyclicAndSpontan\";")]
+        [TestCase("BA_DEF_ BU_ \"Ciao\" ENUM  \"Cyclic\",\"Event\", \"CyclicIfActive\",\"SpontanWithDelay\",\"CyclicAndSpontan\";")]
+        public void PropertyDefinitionSyntaxErrorIsObserved(string line)
+        {
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+            var dbcBuilderMock = m_repository.Create<IDbcBuilder>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+
+            observerMock.Setup(o => o.PropertyDefinitionSyntaxError());
+
+            var lineParser = new PropertiesDefinitionLineParser(observerMock.Object);
+            lineParser.TryParse(line, dbcBuilderMock.Object, nextLineProviderMock.Object);
+        }
+
+        [Test]
+        public void CustomPropertyDuplicateErrorIsObserved()
+        {
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" STRING;";
+            var line2 = $"BA_DEF_ BO_ \"{propertyName}\" INT 0 65535;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+            var dbcBuilder = new DbcBuilder(observerMock.Object);
+
+            observerMock.Setup(o => o.DuplicatedProperty(propertyName));
+
+            var lineParser = new PropertiesDefinitionLineParser(observerMock.Object);
+            lineParser.TryParse(line1, dbcBuilder, nextLineProviderMock.Object);
+            lineParser.TryParse(line2, dbcBuilder, nextLineProviderMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyIntegerWithStringValueErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" INT 0 100;";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} \"50\";";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyHexWithStringValueErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" HEX 0 100;";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} \"50\";";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyFloatWithStringValueErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" FLOAT 0 100;";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} \"50\";";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyIntegerOutOfBoundErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" INT 0 100;";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} 110;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "110"));
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyHexOutOfBoundErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" HEX 0 100;";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} 110;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "110"));
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyFloatOutOfBoundErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" FLOAT 0 100;";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} 110;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "110"));
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyIntegerNotIntegerValueErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" INT 0 100;";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} 1.5;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyHexNotIntegerValueErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" HEX 0 100;";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} 1.5;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyStringNotStringValueErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" STRING;";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} 10;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumNotIntegerIndexValueErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" ENUM \"FirstVal\",\"SecondVal\",\"ThirdVal\";";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} 1.5;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertySyntaxError());
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumOutOfIndexValueErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" ENUM \"FirstVal\",\"SecondVal\",\"ThirdVal\";";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} 3;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfIndex(propertyName, "3"));
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumOutOfBoundValueErrorIsObserved()
+        {
+            uint messageId = 123456;
+            var propertyName = "AttributeName";
+            var line1 = $"BA_DEF_ BO_ \"{propertyName}\" ENUM \"FirstVal\",\"SecondVal\",\"ThirdVal\";";
+            var line2 = $"BA_ \"{propertyName}\" BO_ {messageId} \"3\";";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+
+            observerMock.Setup(o => o.PropertyValueOutOfBound(propertyName, "3"));
+            ParseLine(line1, line2, messageId, observerMock.Object);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumWithIntegerValuesIsParsed()
+        {
+            var dbcString = @"
+BO_ 200 SENSOR: 39 SENSOR
+ BA_DEF_ BO_ ""AttributeName"" ENUM ""1"",""2"",""3"";
+ BA_ ""AttributeName"" BO_ 200 ""3"";";
+
+            var dbc = Parser.Parse(dbcString);
+
+            Assert.AreEqual(1, dbc.Messages.Count());
+            Assert.AreEqual("3", dbc.Messages.First().CustomProperties.Values.First().EnumCustomProperty.Value);
+        }
+
+        [Test]
+        public void DefaultCustomPropertyEnumWithIntegerValuesByIndexIsParsed()
+        {
+            var dbcString = @"
+BO_ 200 SENSOR: 39 SENSOR
+ BA_DEF_ BO_ ""AttributeName"" ENUM ""1"",""2"",""3"";
+ BA_ ""AttributeName"" BO_ 200 2;";
+
+            var dbc = Parser.Parse(dbcString);
+
+            Assert.AreEqual(1, dbc.Messages.Count());
+            Assert.AreEqual("3", dbc.Messages.First().CustomProperties.Values.First().EnumCustomProperty.Value);
+        }
+    }
+}

--- a/DbcParserLib.Tests/SignalLineParserTests.cs
+++ b/DbcParserLib.Tests/SignalLineParserTests.cs
@@ -234,7 +234,7 @@ BO_ 200 SENSOR: 39 SENSOR
             var nextLineProviderMock = m_repository.Create<INextLineProvider>();
             var dbcBuilder = new DbcBuilder(observerMock.Object);
 
-            observerMock.Setup(o => o.DuplicateSignalInMessage(messageId, signalName));
+            observerMock.Setup(o => o.DuplicatedSignalInMessage(messageId, signalName));
 
             var nodeLineParser = new NodeLineParser(observerMock.Object);
             nodeLineParser.TryParse(line1, dbcBuilder, nextLineProviderMock.Object);

--- a/DbcParserLib.Tests/ValueTableLineParserTests.cs
+++ b/DbcParserLib.Tests/ValueTableLineParserTests.cs
@@ -266,7 +266,7 @@ namespace DbcParserLib.Tests
             var nextLineProviderMock = m_repository.Create<INextLineProvider>();
             var dbcBuilder = new DbcBuilder(observerMock.Object);
 
-            observerMock.Setup(o => o.DuplicateValueTableName(tableName));
+            observerMock.Setup(o => o.DuplicatedValueTableName(tableName));
 
             var lineParser = new ValueTableDefinitionLineParser(observerMock.Object);
             lineParser.TryParse(line, dbcBuilder, nextLineProviderMock.Object);

--- a/DbcParserLib/DbcBuilder.cs
+++ b/DbcParserLib/DbcBuilder.cs
@@ -37,7 +37,7 @@ namespace DbcParserLib
         public void AddNode(Node node)
         {
             if(m_nodes.Contains(node))
-                m_observer.DuplicateNode(node.Name);
+                m_observer.DuplicatedNode(node.Name);
             else
                 m_nodes.Add(node);
         }
@@ -47,7 +47,7 @@ namespace DbcParserLib
             if(m_messages.TryGetValue(message.ID, out var msg))
             {
                 m_currentMessage = msg;
-                m_observer.DuplicateMessage(message.ID);
+                m_observer.DuplicatedMessage(message.ID);
             }
             else
             {
@@ -63,7 +63,7 @@ namespace DbcParserLib
             {
                 signal.ID = m_currentMessage.ID;
                 if(m_signals[m_currentMessage.ID].TryGetValue(signal.Name, out _))
-                    m_observer.DuplicateSignalInMessage(m_currentMessage.ID, signal.Name);
+                    m_observer.DuplicatedSignalInMessage(m_currentMessage.ID, signal.Name);
                 else
                     m_signals[m_currentMessage.ID][signal.Name] = signal;
             }
@@ -74,28 +74,28 @@ namespace DbcParserLib
         public void AddCustomProperty(CustomPropertyObjectType objectType, CustomPropertyDefinition customProperty)
         {
             if(m_customProperties[objectType].TryGetValue(customProperty.Name, out _))
-                m_observer.DuplicateCustomProperty(customProperty.Name);
+                m_observer.DuplicatedProperty(customProperty.Name);
             else
                 m_customProperties[objectType][customProperty.Name] = customProperty;
         }
 
-        public void AddCustomPropertyDefaultValue(string propertyName, string value)
+        public void AddCustomPropertyDefaultValue(string propertyName, string value, bool isNumeric)
         {
             var found = false;
             foreach(var objectType in m_customProperties.Keys)
             {
                 if (m_customProperties[objectType].TryGetValue(propertyName, out var customProperty))
                 {
-                    customProperty.SetCustomPropertyDefaultValue(value);
+                    customProperty.SetCustomPropertyDefaultValue(value, isNumeric);
                     found = true;
                 }
             }
 
             if(!found)
-                m_observer.CustomPropertyNameNotFound(propertyName);
+                m_observer.PropertyNameNotFound(propertyName);
         }
 
-        public void AddNodeCustomProperty(string propertyName, string nodeName, string value)
+        public void AddNodeCustomProperty(string propertyName, string nodeName, string value, bool isNumeric)
         {
             if(m_customProperties[CustomPropertyObjectType.Node].TryGetValue(propertyName, out var customProperty))
             {
@@ -103,9 +103,9 @@ namespace DbcParserLib
                 if (node != null)
                 {
                     var property = new CustomProperty(customProperty);
-                    property.SetCustomPropertyValue(value);
+                    property.SetCustomPropertyValue(value, isNumeric);
                     if(node.CustomProperties.TryGetValue(propertyName, out _))
-                        m_observer.DuplicateCustomPropertyInNode(propertyName, node.Name);
+                        m_observer.DuplicatedPropertyInNode(propertyName, node.Name);
                     else
                         node.CustomProperties[propertyName] = property;
                 }
@@ -113,19 +113,19 @@ namespace DbcParserLib
                     m_observer.NodeNameNotFound(nodeName);
             }
             else
-                m_observer.CustomPropertyNameNotFound(propertyName);
+                m_observer.PropertyNameNotFound(propertyName);
         }
 
-        public void AddEnvironmentVariableCustomProperty(string propertyName, string variableName, string value)
+        public void AddEnvironmentVariableCustomProperty(string propertyName, string variableName, string value, bool isNumeric)
         {
             if (m_customProperties[CustomPropertyObjectType.Environment].TryGetValue(propertyName, out var customProperty))
             {
                 if (m_environmentVariables.TryGetValue(variableName, out var envVariable))
                 {
                     var property = new CustomProperty(customProperty);
-                    property.SetCustomPropertyValue(value);
+                    property.SetCustomPropertyValue(value, isNumeric);
                     if(envVariable.CustomProperties.TryGetValue(propertyName, out _))
-                        m_observer.DuplicateCustomPropertyInEnvironmentVariable(propertyName, envVariable.Name);
+                        m_observer.DuplicatedPropertyInEnvironmentVariable(propertyName, envVariable.Name);
                     else
                         envVariable.CustomProperties[propertyName] = property;
                 }
@@ -133,19 +133,19 @@ namespace DbcParserLib
                     m_observer.EnvironmentVariableNameNotFound(variableName);
             }
             else
-                m_observer.CustomPropertyNameNotFound(propertyName);
+                m_observer.PropertyNameNotFound(propertyName);
         }
 
-        public void AddMessageCustomProperty(string propertyName, uint messageId, string value)
+        public void AddMessageCustomProperty(string propertyName, uint messageId, string value, bool isNumeric)
         {
             if (m_customProperties[CustomPropertyObjectType.Message].TryGetValue(propertyName, out var customProperty))
             {
                 if (m_messages.TryGetValue(messageId, out var message))
                 {
                     var property = new CustomProperty(customProperty);
-                    property.SetCustomPropertyValue(value);
+                    property.SetCustomPropertyValue(value, isNumeric);
                     if(message.CustomProperties.TryGetValue(propertyName, out _))
-                        m_observer.DuplicateCustomPropertyInMessage(propertyName, message.ID);
+                        m_observer.DuplicatedPropertyInMessage(propertyName, message.ID);
                     else
                         message.CustomProperties[propertyName] = property;
                 }
@@ -153,19 +153,19 @@ namespace DbcParserLib
                     m_observer.MessageIdNotFound(messageId);
             }
             else
-                m_observer.CustomPropertyNameNotFound(propertyName);
+                m_observer.PropertyNameNotFound(propertyName);
         }
 
-        public void AddSignalCustomProperty(string propertyName, uint messageId, string signalName, string value)
+        public void AddSignalCustomProperty(string propertyName, uint messageId, string signalName, string value, bool isNumeric)
         {
             if (m_customProperties[CustomPropertyObjectType.Signal].TryGetValue(propertyName, out var customProperty))
             {
                 if (TryGetValueMessageSignal(messageId, signalName, out var signal))
                 {
                     var property = new CustomProperty(customProperty);
-                    property.SetCustomPropertyValue(value);
+                    property.SetCustomPropertyValue(value, isNumeric);
                     if(signal.CustomProperties.TryGetValue(propertyName, out _))
-                        m_observer.DuplicateCustomPropertyInSignal(propertyName, signal.Name);
+                        m_observer.DuplicatedPropertyInSignal(propertyName, signal.Name);
                     else
                         signal.CustomProperties[propertyName] = property;
                 }
@@ -173,7 +173,7 @@ namespace DbcParserLib
                     m_observer.SignalNameNotFound(messageId, signalName);
             }
             else
-                m_observer.CustomPropertyNameNotFound(propertyName);
+                m_observer.PropertyNameNotFound(propertyName);
         }
 
         public void AddSignalComment(uint messageId, string signalName, string comment)
@@ -230,7 +230,7 @@ namespace DbcParserLib
         public void AddEnvironmentVariable(string variableName, EnvironmentVariable environmentVariable)
         {
             if(m_environmentVariables.TryGetValue(variableName, out _))
-                m_observer.DuplicateEnvironmentVariableName(variableName);
+                m_observer.DuplicatedEnvironmentVariableName(variableName);
             else
                 m_environmentVariables[variableName] = environmentVariable;
         }
@@ -255,7 +255,7 @@ namespace DbcParserLib
             if (node != null)
             {
                 if(node.EnvironmentVariables.TryGetValue(variableName, out _))
-                    m_observer.DuplicateEnvironmentVariableInNode(variableName, node.Name);
+                    m_observer.DuplicatedEnvironmentVariableInNode(variableName, node.Name);
                 else
                     node.EnvironmentVariables[variableName] = m_environmentVariables[variableName];
             }
@@ -276,7 +276,7 @@ namespace DbcParserLib
         public void AddNamedValueTable(string name, IReadOnlyDictionary<int, string> dictValues, string stringValues)
         {
             if(m_namedTablesMap.TryGetValue(name, out _))
-                m_observer.DuplicateValueTableName(name);
+                m_observer.DuplicatedValueTableName(name);
             else
             {
                 m_namedTablesMap[name] = new ValuesTable()

--- a/DbcParserLib/IDbcBuilder.cs
+++ b/DbcParserLib/IDbcBuilder.cs
@@ -19,11 +19,11 @@ namespace DbcParserLib
         void LinkTableValuesToSignal(uint messageId, string signalName, IReadOnlyDictionary<int, string> dictValues, string stringValues);
         void LinkTableValuesToEnvironmentVariable(string variableName, IReadOnlyDictionary<int, string> dictValues);
         void AddCustomProperty(CustomPropertyObjectType objectType, CustomPropertyDefinition customProperty);
-        void AddCustomPropertyDefaultValue(string propertyName, string value);
-        void AddNodeCustomProperty(string propertyName, string nodeName, string value);
-        void AddEnvironmentVariableCustomProperty(string propertyName, string variableName, string value);
-        void AddMessageCustomProperty(string propertyName, uint messageId, string value);
-        void AddSignalCustomProperty(string propertyName, uint messageId, string signalName, string value);
+        void AddCustomPropertyDefaultValue(string propertyName, string value, bool isNumeric);
+        void AddNodeCustomProperty(string propertyName, string nodeName, string value, bool isNumeric);
+        void AddEnvironmentVariableCustomProperty(string propertyName, string variableName, string value, bool isNumeric);
+        void AddMessageCustomProperty(string propertyName, uint messageId, string value, bool isNumeric);
+        void AddSignalCustomProperty(string propertyName, uint messageId, string signalName, string value, bool isNumeric);
         void AddEnvironmentVariable(string variableName, EnvironmentVariable environmentVariable);
         void AddEnvironmentVariableComment(string variableName, string comment);
         void AddEnvironmentDataVariable(string variableName, uint dataSize);

--- a/DbcParserLib/Model/CustomProperty.cs
+++ b/DbcParserLib/Model/CustomProperty.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace DbcParserLib.Model
+﻿namespace DbcParserLib.Model
 {
     public class CustomProperty
     {
@@ -16,38 +14,55 @@ namespace DbcParserLib.Model
             CustomPropertyDefinition = customPropertyDefinition;
         }
 
-        public void SetCustomPropertyValue(string value)
+        public void SetCustomPropertyValue(string value, bool isNumeric)
         {
             switch (CustomPropertyDefinition.DataType)
             {
                 case CustomPropertyDataType.Integer:
+                    if(!CustomPropertyDefinition.TryGetIntegerValue(value, isNumeric, out var integerValue))
+                        return;
+
                     IntegerCustomProperty = new CustomPropertyValue<int>()
                     {
-                        Value = int.Parse(value, CultureInfo.InvariantCulture)
+                        Value = integerValue
                     };
                     break;
+
                 case CustomPropertyDataType.Hex:
+                    if(!CustomPropertyDefinition.TryGetHexValue(value, isNumeric, out var hexValue))
+                        return;
+
                     HexCustomProperty = new CustomPropertyValue<int>()
                     {
-                        Value = int.Parse(value, CultureInfo.InvariantCulture)
+                        Value = hexValue
                     };
                     break;
+
                 case CustomPropertyDataType.Float:
+                    if(!CustomPropertyDefinition.TryGetFloatValue(value, isNumeric, out var floatValue))
+                        return;
                     FloatCustomProperty = new CustomPropertyValue<double>()
                     {
-                        Value = float.Parse(value, CultureInfo.InvariantCulture)
+                        Value = floatValue
                     };
                     break;
+
                 case CustomPropertyDataType.String:
+                    if(!CustomPropertyDefinition.IsString(isNumeric))
+                        return;
                     StringCustomProperty = new CustomPropertyValue<string>()
                     {
                         Value = value
                     };
                     break;
+
                 case CustomPropertyDataType.Enum:
+                    if(!CustomPropertyDefinition.TryGetEnumValue(value, isNumeric, out var enumValue))
+                        return;
+
                     EnumCustomProperty = new CustomPropertyValue<string>()
                     {
-                        Value = value
+                        Value = enumValue
                     };
                     break;
             }

--- a/DbcParserLib/Model/CustomPropertyDefinition.cs
+++ b/DbcParserLib/Model/CustomPropertyDefinition.cs
@@ -1,9 +1,12 @@
 ﻿using System.Globalization;
+using System.Linq;
+using DbcParserLib.Observers;
 
 namespace DbcParserLib.Model
 {
     public class CustomPropertyDefinition
     {
+        private readonly IParseFailureObserver m_observer;
         public string Name { get; set; }
         public CustomPropertyDataType DataType { get; set; }
         public NumericCustomPropertyDefinition<int> IntegerCustomProperty { get; set; }
@@ -12,26 +15,174 @@ namespace DbcParserLib.Model
         public StringCustomPropertyDefinition StringCustomProperty { get; set; }
         public EnumCustomPropertyDefinition EnumCustomProperty { get; set; }
 
-        public void SetCustomPropertyDefaultValue(string value)
+        public CustomPropertyDefinition(IParseFailureObserver observer)
+        {
+            m_observer = observer;
+        }
+
+
+        public void SetCustomPropertyDefaultValue(string value, bool isNumeric)
         {
             switch (DataType)
             {
                 case CustomPropertyDataType.Integer:
-                    IntegerCustomProperty.Default = int.Parse(value, CultureInfo.InvariantCulture);
+                    if(!TryGetIntegerValue(value, isNumeric, out var integerValue))
+                        return;
+                    IntegerCustomProperty.Default = integerValue;
                     break;
+
                 case CustomPropertyDataType.Hex:
-                    HexCustomProperty.Default = int.Parse(value, CultureInfo.InvariantCulture);
+                    if(!TryGetHexValue(value, isNumeric, out var hexValue))
+                        return;
+                    HexCustomProperty.Default = hexValue;
                     break;
+
                 case CustomPropertyDataType.Float:
-                    FloatCustomProperty.Default = float.Parse(value, CultureInfo.InvariantCulture);
+                    if(!TryGetFloatValue(value, isNumeric, out var floatValue))
+                        return;
+                    FloatCustomProperty.Default = floatValue;
                     break;
+
                 case CustomPropertyDataType.String:
+                    if(!IsString(isNumeric))
+                        return;
                     StringCustomProperty.Default = value;
                     break;
+
                 case CustomPropertyDataType.Enum:
-                    EnumCustomProperty.Default = value;
+                    if(!TryGetEnumValue(value, isNumeric, out var enumValue))
+                        return;
+                    EnumCustomProperty.Default = enumValue;
                     break;
             }
+        }
+
+        internal bool TryGetIntegerValue(string value, bool isNumeric, out int integerValue)
+        {
+            integerValue = 0;
+            if (!isNumeric)
+            {
+                m_observer.PropertySyntaxError();
+                return false;
+            }
+
+            if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture,
+                    out integerValue))
+            {
+                m_observer.PropertySyntaxError();
+                return false;
+            }
+
+            if (integerValue < IntegerCustomProperty.Minimum || integerValue > IntegerCustomProperty.Maximum)
+            {
+                m_observer.PropertyValueOutOfBound(Name, value);
+                return false;
+            }
+
+            return true;
+        }
+
+        internal bool TryGetHexValue(string value, bool isNumeric, out int hexValue)
+        {
+            hexValue = 0;
+            if (!isNumeric)
+            {
+                m_observer.PropertySyntaxError();
+                return false;
+            }
+
+            if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture,
+                    out hexValue))
+            {
+                m_observer.PropertySyntaxError();
+                return false;
+            }
+
+            if (hexValue < HexCustomProperty.Minimum || hexValue > HexCustomProperty.Maximum)
+            {
+                m_observer.PropertyValueOutOfBound(Name, value);
+                return false;
+            }
+
+            return true;
+        }
+
+        internal bool TryGetFloatValue(string value, bool isNumeric, out float floatValue)
+        {
+            floatValue = 0;
+            if (!isNumeric)
+            {
+                m_observer.PropertySyntaxError();
+                return false;
+            }
+
+            if (!float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture,
+                    out floatValue))
+            {
+                m_observer.PropertySyntaxError();
+                return false;
+            }
+
+            if (floatValue < FloatCustomProperty.Minimum || floatValue > FloatCustomProperty.Maximum)
+            {
+                m_observer.PropertyValueOutOfBound(Name, value);
+                return false;
+            }
+
+            return true;
+        }
+
+        internal bool IsString(bool isNumeric)
+        {
+            if (isNumeric)
+            {
+                m_observer.PropertySyntaxError();
+                return false;
+            }
+
+            return true;
+        }
+
+        internal bool TryGetEnumValue(string value, bool isNumeric, out string enumValue)
+        {
+            enumValue = null;
+            if (isNumeric)
+            {
+                if (!TryGetEnumValueFromIndex(value, out enumValue))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (!EnumCustomProperty.Values.Contains(value))
+                {
+                    m_observer.PropertyValueOutOfBound(Name, value);
+                    return false;
+                }
+                enumValue = value;
+            }
+            return true;
+        }
+
+        private bool TryGetEnumValueFromIndex(string value, out string enumValue)
+        {
+            enumValue = null;
+
+            if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index))
+            {
+                m_observer.PropertySyntaxError();
+                return false;
+            }
+
+            if (index < 0 || index >= EnumCustomProperty.Values.Length)
+            {
+                m_observer.PropertyValueOutOfIndex(Name, value);
+                return false;
+            }
+            
+            enumValue = EnumCustomProperty.Values[index];
+            return true;
         }
     }
 

--- a/DbcParserLib/Observers/IParseFailureObserver.cs
+++ b/DbcParserLib/Observers/IParseFailureObserver.cs
@@ -4,17 +4,17 @@
     {
         int CurrentLine {get; set;}
 
-        void DuplicateMessage(uint messageId);
-        void DuplicateNode(string nodeName);
-        void DuplicateSignalInMessage(uint messageId, string signalName);
-        void DuplicateValueTableName(string tableName);
-        void DuplicateEnvironmentVariableName(string variableName);
-        void DuplicateCustomProperty(string propertyName);
-        void DuplicateCustomPropertyInNode(string propertyName, string nodeName);
-        void DuplicateCustomPropertyInEnvironmentVariable(string propertyName, string environmentVariableName);
-        void DuplicateCustomPropertyInMessage(string propertyName, uint messageId);
-        void DuplicateCustomPropertyInSignal(string propertyName, string signalName);
-        void DuplicateEnvironmentVariableInNode(string environmentVariableName, string nodeName);
+        void DuplicatedMessage(uint messageId);
+        void DuplicatedNode(string nodeName);
+        void DuplicatedSignalInMessage(uint messageId, string signalName);
+        void DuplicatedValueTableName(string tableName);
+        void DuplicatedEnvironmentVariableName(string variableName);
+        void DuplicatedProperty(string propertyName);
+        void DuplicatedPropertyInNode(string propertyName, string nodeName);
+        void DuplicatedPropertyInEnvironmentVariable(string propertyName, string environmentVariableName);
+        void DuplicatedPropertyInMessage(string propertyName, uint messageId);
+        void DuplicatedPropertyInSignal(string propertyName, string signalName);
+        void DuplicatedEnvironmentVariableInNode(string environmentVariableName, string nodeName);
         void CommentSyntaxError();
         void EnvironmentDataVariableSyntaxError();
         void MessageSyntaxError();
@@ -31,8 +31,10 @@
         void NodeNameNotFound(string nodeName);
         void MessageIdNotFound(uint messageId);
         void EnvironmentVariableNameNotFound(string variableName);
-        void CustomPropertyNameNotFound(string propertyName);
+        void PropertyNameNotFound(string propertyName);
         void TableMapNameNotFound(string tableName);
+        void PropertyValueOutOfBound(string propertyName, string value);
+        void PropertyValueOutOfIndex(string propertyName, string index);
         void UnknownLine();
         void NoMessageFound();
         void Clear();

--- a/DbcParserLib/Observers/SilentFailureObserver.cs
+++ b/DbcParserLib/Observers/SilentFailureObserver.cs
@@ -4,47 +4,47 @@ namespace DbcParserLib.Observers
     {
         public int CurrentLine {get; set;}
 
-        public void DuplicateMessage(uint messageId)
+        public void DuplicatedMessage(uint messageId)
         {
         }
 
-        public void DuplicateNode(string nodeName)
+        public void DuplicatedNode(string nodeName)
         {
         }
 
-        public void DuplicateSignalInMessage(uint messageId, string signalName)
+        public void DuplicatedSignalInMessage(uint messageId, string signalName)
         {
         }
 
-        public void DuplicateValueTableName(string tableName)
+        public void DuplicatedValueTableName(string tableName)
         {
         }
 
-        public void DuplicateEnvironmentVariableName(string variableName)
+        public void DuplicatedEnvironmentVariableName(string variableName)
         {
         }
 
-        public void DuplicateCustomProperty(string propertyName)
+        public void DuplicatedProperty(string propertyName)
         {
         }
 
-        public void DuplicateCustomPropertyInNode(string propertyName, string nodeName)
+        public void DuplicatedPropertyInNode(string propertyName, string nodeName)
         {
         }
 
-        public void DuplicateCustomPropertyInEnvironmentVariable(string propertyName, string environmentVariableName)
+        public void DuplicatedPropertyInEnvironmentVariable(string propertyName, string environmentVariableName)
         {
         }
 
-        public void DuplicateCustomPropertyInMessage(string propertyName, uint messageId)
+        public void DuplicatedPropertyInMessage(string propertyName, uint messageId)
         {
         }
 
-        public void DuplicateCustomPropertyInSignal(string propertyName, string signalName)
+        public void DuplicatedPropertyInSignal(string propertyName, string signalName)
         {
         }
 
-        public void DuplicateEnvironmentVariableInNode(string environmentVariableName, string nodeName)
+        public void DuplicatedEnvironmentVariableInNode(string environmentVariableName, string nodeName)
         {
         }
 
@@ -112,11 +112,19 @@ namespace DbcParserLib.Observers
         {
         }
 
-        public void CustomPropertyNameNotFound(string propertyName)
+        public void PropertyNameNotFound(string propertyName)
         {
         }
 
         public void TableMapNameNotFound(string tableName)
+        {
+        }
+
+        public void PropertyValueOutOfBound(string propertyName, string value)
+        {
+        }
+
+        public void PropertyValueOutOfIndex(string propertyName, string index)
         {
         }
 

--- a/DbcParserLib/Observers/SimpleFailureObserver.cs
+++ b/DbcParserLib/Observers/SimpleFailureObserver.cs
@@ -14,57 +14,57 @@ namespace DbcParserLib.Observers
             m_errors.Add($"{error} at line {CurrentLine}");
         }
 
-        public void DuplicateMessage(uint messageId)
+        public void DuplicatedMessage(uint messageId)
         {
             AddError($"Duplicated message (ID {messageId})");
         }
 
-        public void DuplicateNode(string nodeName)
+        public void DuplicatedNode(string nodeName)
         {
             AddError($"Duplicated node '{nodeName}'");
         }
 
-        public void DuplicateSignalInMessage(uint messageId, string signalName)
+        public void DuplicatedSignalInMessage(uint messageId, string signalName)
         {
             AddError($"Duplicated signal '{signalName}' in message (ID {messageId})");
         }
 
-        public void DuplicateValueTableName(string tableName)
+        public void DuplicatedValueTableName(string tableName)
         {
             AddError($"Duplicated value table '{tableName}'");
         }
 
-        public void DuplicateEnvironmentVariableName(string variableName)
+        public void DuplicatedEnvironmentVariableName(string variableName)
         {
             AddError($"Duplicated environment variable '{variableName}'");
         }
 
-        public void DuplicateCustomProperty(string propertyName)
+        public void DuplicatedProperty(string propertyName)
         {
             AddError($"Duplicated custom property '{propertyName}'");
         }
 
-        public void DuplicateCustomPropertyInNode(string propertyName, string nodeName)
+        public void DuplicatedPropertyInNode(string propertyName, string nodeName)
         {
             AddError($"Duplicated custom property '{propertyName}' in node '{nodeName}'");
         }
 
-        public void DuplicateCustomPropertyInEnvironmentVariable(string propertyName, string environmentVariableName)
+        public void DuplicatedPropertyInEnvironmentVariable(string propertyName, string environmentVariableName)
         {
             AddError($"Duplicated custom property '{propertyName}' in environment variable '{environmentVariableName}'");
         }
 
-        public void DuplicateCustomPropertyInMessage(string propertyName, uint messageId)
+        public void DuplicatedPropertyInMessage(string propertyName, uint messageId)
         {
             AddError($"Duplicated custom property '{propertyName}' in message (ID {messageId})");
         }
 
-        public void DuplicateCustomPropertyInSignal(string propertyName, string signalName)
+        public void DuplicatedPropertyInSignal(string propertyName, string signalName)
         {
             AddError($"Duplicated custom property '{propertyName}' in signal '{signalName}'");
         }
 
-        public void DuplicateEnvironmentVariableInNode(string environmentVariableName, string nodeName)
+        public void DuplicatedEnvironmentVariableInNode(string environmentVariableName, string nodeName)
         {
             AddError($"Duplicated environment variable '{environmentVariableName}' in node '{nodeName}'");
         }
@@ -149,7 +149,7 @@ namespace DbcParserLib.Observers
             AddError($"Environment variable '{variableName}' not found");
         }
 
-        public void CustomPropertyNameNotFound(string propertyName)
+        public void PropertyNameNotFound(string propertyName)
         {
             AddError($"Custom property '{propertyName}' not found");
         }
@@ -157,6 +157,16 @@ namespace DbcParserLib.Observers
         public void TableMapNameNotFound(string tableName)
         {
             AddError($"Table map '{tableName}' not found");
+        }
+
+        public void PropertyValueOutOfBound(string propertyName, string value)
+        {
+            AddError($"Out of bound value [{value}] for '{propertyName}' property");
+        }
+
+        public void PropertyValueOutOfIndex(string propertyName, string index)
+        {
+            AddError($"Out of index value [{index}] for '{propertyName}' property");
         }
 
         public void UnknownLine()

--- a/DbcParserLib/Parsers/PropertiesDefinitionLineParser.cs
+++ b/DbcParserLib/Parsers/PropertiesDefinitionLineParser.cs
@@ -9,9 +9,7 @@ namespace DbcParserLib.Parsers
     {
         private const string PropertiesDefinitionLineStarter = "BA_DEF_ ";
         private const string PropertiesDefinitionDefaultLineStarter = "BA_DEF_DEF_ ";
-        // language=regex
         private const string PropertyDefinitionParsingRegex = @"BA_DEF_(?:\s+(BU_|BO_|SG_|EV_))?\s+""([a-zA-Z_][\w]*)""\s+(?:(?:(INT|HEX)\s+(-?\d+)\s+(-?\d+))|(?:(FLOAT)\s+([\d\+\-eE.]+)\s+([\d\+\-eE.]+))|(STRING)|(?:(ENUM)\s+((?:""[^""]*"",+)*(?:""[^""]*""))))\s*;";
-        // language=regex
         private const string PropertyDefinitionDefaultParsingRegex = @"BA_DEF_DEF_\s+""([a-zA-Z_][\w]*)""\s+(-?\d+|[\d\+\-eE.]+|""[^""]*"")\s*;";
 
         private readonly IParseFailureObserver m_observer;
@@ -33,7 +31,7 @@ namespace DbcParserLib.Parsers
             {
                 var match = Regex.Match(cleanLine, PropertyDefinitionDefaultParsingRegex);
                 if (match.Success)
-                    builder.AddCustomPropertyDefaultValue(match.Groups[1].Value, match.Groups[2].Value.Replace("\"", ""));
+                    builder.AddCustomPropertyDefaultValue(match.Groups[1].Value, match.Groups[2].Value.Replace("\"", ""), !match.Groups[2].Value.StartsWith("\""));
                 else
                     m_observer.PropertyDefaultSyntaxError();
                 return true;
@@ -44,7 +42,7 @@ namespace DbcParserLib.Parsers
                 var match = Regex.Match(cleanLine, PropertyDefinitionParsingRegex);
                 if (match.Success)
                 {
-                    var customProperty = new CustomPropertyDefinition
+                    var customProperty = new CustomPropertyDefinition(m_observer)
                     {
                         Name = match.Groups[2].Value,
                     };

--- a/DbcParserLib/Parsers/PropertiesLineParser.cs
+++ b/DbcParserLib/Parsers/PropertiesLineParser.cs
@@ -26,19 +26,22 @@ namespace DbcParserLib.Parsers
             var match = Regex.Match(cleanLine, PropertyParsingRegex);
             if (match.Success)
             {
+                var isNumeric = !match.Groups[9].Value.StartsWith("\"");
+                var stringValue = match.Groups[9].Value.Replace("\"", "");
+
                 if (match.Groups[2].Value == "BU_")
-                    builder.AddNodeCustomProperty(match.Groups[1].Value, match.Groups[3].Value, match.Groups[9].Value.Replace("\"", ""));
+                    builder.AddNodeCustomProperty(match.Groups[1].Value, match.Groups[3].Value, stringValue, isNumeric);
                 else if (match.Groups[2].Value == "EV_")
-                    builder.AddEnvironmentVariableCustomProperty(match.Groups[1].Value, match.Groups[3].Value, match.Groups[9].Value.Replace("\"", ""));
+                    builder.AddEnvironmentVariableCustomProperty(match.Groups[1].Value, match.Groups[3].Value, stringValue, isNumeric);
                 else if (match.Groups[4].Value == "BO_")
                 {
-                    builder.AddMessageCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture), match.Groups[9].Value.Replace("\"", ""));
+                    builder.AddMessageCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture), stringValue, isNumeric);
                     if (match.Groups[1].Value == "GenMsgCycleTime")
                         builder.AddMessageCycleTime(uint.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture), int.Parse(match.Groups[9].Value, CultureInfo.InvariantCulture));
                 }
                 else if (match.Groups[6].Value == "SG_")
                 {
-                    builder.AddSignalCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture), match.Groups[8].Value, match.Groups[9].Value.Replace("\"", ""));
+                    builder.AddSignalCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture), match.Groups[8].Value, stringValue, isNumeric);
                     if (match.Groups[1].Value == "GenSigStartValue")
                         builder.AddSignalInitialValue(uint.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture), match.Groups[8].Value, double.Parse(match.Groups[9].Value, CultureInfo.InvariantCulture));
                 }


### PR DESCRIPTION
Custom property parsing failures rework and refactoring. Added to the IParseFailureObserver the methods to notify the user if:
- a property value cannot be handled (e.g. int property receiving a string, a string property receiving an int, etc...)
- a provided enum value is not part of the enum values listed as valid
- a provided enum index is out of index (e.g. enum definition has 4 values, you provide index 5 as value)
- a provided property value is out of bound (e.g. int value is greater/lower than min/max value)