### PR TITLE
fixed parsing failure when additional spaces occur before semicolon

### DIFF
--- a/DbcParserLib/ExtensionsAndHelpers.cs
+++ b/DbcParserLib/ExtensionsAndHelpers.cs
@@ -87,8 +87,13 @@ namespace DbcParserLib
             {
                 while (reader.Peek() > -1)
                 {
+                    var line = reader.ReadLine();
+                    
+                    if (string.IsNullOrWhiteSpace(line))
+                        continue;
+                    
                     // Add duplicated key control and act (eg. strict -> break, warning -> keep going and log, silent-> keep going)
-                    var tokens = reader.ReadLine().Split(' ');
+                    var tokens = line.Split(' ');
                     dict[int.Parse(tokens[0])] = tokens[1];
                 }
             }


### PR DESCRIPTION
when VAL_ or VAL_TABLE_ finish with semicolon that is prefixed by multiple spaces (3 in my case), then the `ExtensionsAndHelpers.ToDictionary` records variable will hold `\r\n ` (there is space after). This causes the tokens will be an array of two items with values of string.Empty for both. This causing int.Parse to fail.

I've fixed that so it won't occur anymore.