### PR TITLE
Default custom property refactoring

### DIFF
--- a/DbcParserLib.Tests/PropertiesLineParserTests.cs
+++ b/DbcParserLib.Tests/PropertiesLineParserTests.cs
@@ -170,7 +170,9 @@ namespace DbcParserLib.Tests
             Assert.IsTrue(ParseLine(@"BA_ ""GenMsgCycleTime"" BO_ 2394947585 100;", msgCycleTimeLineParser, builder, nextLineProvider));
 
             var dbc = builder.Build();
+            Assert.AreEqual(true, dbc.Messages.First().CycleTime(out var cycleTime));
             Assert.AreEqual(100, dbc.Messages.First().CycleTime);
+            Assert.AreEqual(100, cycleTime);
         }
 
         [Test]

--- a/DbcParserLib.Tests/PropertiesLineParserTests.cs
+++ b/DbcParserLib.Tests/PropertiesLineParserTests.cs
@@ -157,7 +157,7 @@ namespace DbcParserLib.Tests
         }
 
         [Test]
-        public void MsgCustomPropertyIsParsedTest()
+        public void MsgCycleTimePropertyIsParsedTest()
         {
             var builder = new DbcBuilder(new SilentFailureObserver());
             var message = new Message { ID = 2394947585 };
@@ -176,7 +176,7 @@ namespace DbcParserLib.Tests
         }
 
         [Test]
-        public void SigCustomPropertyIsParsedTest()
+        public void SigInitialValueIntegerPropertyIsParsedTest()
         {
             var builder = new DbcBuilder(new SilentFailureObserver());
             var message = new Message { ID = 2394947585 };
@@ -191,7 +191,30 @@ namespace DbcParserLib.Tests
             Assert.IsTrue(ParseLine(@"BA_ ""GenSigStartValue"" SG_ 2394947585 sig_name 40;", sigInitialValueLineParser, builder, nextLineProvider));
 
             var dbc = builder.Build();
+            Assert.AreEqual(true, dbc.Messages.First().Signals.First().InitialValue(out var initialValue));
             Assert.AreEqual(40, dbc.Messages.First().Signals.First().InitialValue);
+            Assert.AreEqual(40, initialValue);
+        }
+
+        [Test]
+        public void SigInitialValueHexPropertyIsParsedTest()
+        {
+            var builder = new DbcBuilder(new SilentFailureObserver());
+            var message = new Message { ID = 2394947585 };
+            builder.AddMessage(message);
+            var signal = new Signal { Name = "sig_name" };
+            builder.AddSignal(signal);
+
+            var sigInitialValueLineParser = CreateParser();
+            var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
+            Assert.IsTrue(ParseLine(@"BA_DEF_ SG_ ""GenSigStartValue"" HEX 0 200;", sigInitialValueLineParser, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""GenSigStartValue"" 150;", sigInitialValueLineParser, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_ ""GenSigStartValue"" SG_ 2394947585 sig_name 40;", sigInitialValueLineParser, builder, nextLineProvider));
+
+            var dbc = builder.Build();
+            Assert.AreEqual(true, dbc.Messages.First().Signals.First().InitialValue(out var initialValue));
+            Assert.AreEqual(40, dbc.Messages.First().Signals.First().InitialValue);
+            Assert.AreEqual(40, initialValue);
         }
 
         [Test]

--- a/DbcParserLib/DbcBuilder.cs
+++ b/DbcParserLib/DbcBuilder.cs
@@ -103,7 +103,9 @@ namespace DbcParserLib
                 if (node != null)
                 {
                     var property = new CustomProperty(customProperty);
-                    property.SetCustomPropertyValue(value, isNumeric);
+                    if(!property.SetCustomPropertyValue(value, isNumeric))
+                        return;
+
                     if(node.CustomProperties.TryGetValue(propertyName, out _))
                         m_observer.DuplicatedPropertyInNode(propertyName, node.Name);
                     else
@@ -123,7 +125,9 @@ namespace DbcParserLib
                 if (m_environmentVariables.TryGetValue(variableName, out var envVariable))
                 {
                     var property = new CustomProperty(customProperty);
-                    property.SetCustomPropertyValue(value, isNumeric);
+                    if(!property.SetCustomPropertyValue(value, isNumeric))
+                        return;
+
                     if(envVariable.CustomProperties.TryGetValue(propertyName, out _))
                         m_observer.DuplicatedPropertyInEnvironmentVariable(propertyName, envVariable.Name);
                     else
@@ -143,7 +147,9 @@ namespace DbcParserLib
                 if (m_messages.TryGetValue(messageId, out var message))
                 {
                     var property = new CustomProperty(customProperty);
-                    property.SetCustomPropertyValue(value, isNumeric);
+                    if(!property.SetCustomPropertyValue(value, isNumeric))
+                        return;
+
                     if(message.CustomProperties.TryGetValue(propertyName, out _))
                         m_observer.DuplicatedPropertyInMessage(propertyName, message.ID);
                     else
@@ -163,7 +169,9 @@ namespace DbcParserLib
                 if (TryGetValueMessageSignal(messageId, signalName, out var signal))
                 {
                     var property = new CustomProperty(customProperty);
-                    property.SetCustomPropertyValue(value, isNumeric);
+                    if(!property.SetCustomPropertyValue(value, isNumeric))
+                        return;
+
                     if(signal.CustomProperties.TryGetValue(propertyName, out _))
                         m_observer.DuplicatedPropertyInSignal(propertyName, signal.Name);
                     else

--- a/DbcParserLib/DbcBuilder.cs
+++ b/DbcParserLib/DbcBuilder.cs
@@ -184,14 +184,6 @@ namespace DbcParserLib
                 m_observer.SignalNameNotFound(messageId, signalName);
         }
 
-        public void AddSignalInitialValue(uint messageId, string signalName, double initialValue)
-        {
-            if (TryGetValueMessageSignal(messageId, signalName, out var signal))
-                signal.InitialValue = initialValue * signal.Factor + signal.Offset;
-            else
-                m_observer.SignalNameNotFound(messageId, signalName);
-        }
-
         public void AddSignalValueType(uint messageId, string signalName, DbcValueType valueType)
         {
             if (TryGetValueMessageSignal(messageId, signalName, out var signal))

--- a/DbcParserLib/DbcBuilder.cs
+++ b/DbcParserLib/DbcBuilder.cs
@@ -263,16 +263,6 @@ namespace DbcParserLib
                 m_observer.NodeNameNotFound(nodeName);
         }
 
-        public void AddMessageCycleTime(uint messageId, int cycleTime)
-        {
-            if (m_messages.TryGetValue(messageId, out var message))
-            {
-                message.CycleTime = cycleTime;
-            }
-            else
-                m_observer.MessageIdNotFound(messageId);
-        }
-
         public void AddNamedValueTable(string name, IReadOnlyDictionary<int, string> dictValues, string stringValues)
         {
             if(m_namedTablesMap.TryGetValue(name, out _))

--- a/DbcParserLib/ExtensionsAndHelpers.cs
+++ b/DbcParserLib/ExtensionsAndHelpers.cs
@@ -102,16 +102,44 @@ namespace DbcParserLib
 
         public static bool CycleTime(this Message message, out int cycleTime)
         {
+            cycleTime = 0;
+
             if (message.CustomProperties.TryGetValue("GenMsgCycleTime", out var property))
             {
                 cycleTime = property.IntegerCustomProperty.Value;
                 return true;
             }
             else
-            {
-                cycleTime = 0;
                 return false;
+        }
+
+        internal static bool InitialValue(this Signal signal, out double initialValue)
+        {
+            initialValue = 0;
+
+            if (signal.CustomProperties.TryGetValue("GenSigStartValue", out var property))
+            {
+                double value = 0;
+                switch (property.CustomPropertyDefinition.DataType)
+                {
+                    case CustomPropertyDataType.Float:
+                        value = property.FloatCustomProperty.Value;
+                        break;
+                    case CustomPropertyDataType.Hex:
+                        value = property.HexCustomProperty.Value;
+                        break;
+                    case CustomPropertyDataType.Integer:
+                        value = property.IntegerCustomProperty.Value;
+                        break;
+                    default:
+                        return false;
+                }
+
+                initialValue = value * signal.Factor + signal.Offset;
+                return true;
             }
+            else
+                return false;
         }
     }
 }

--- a/DbcParserLib/ExtensionsAndHelpers.cs
+++ b/DbcParserLib/ExtensionsAndHelpers.cs
@@ -99,5 +99,19 @@ namespace DbcParserLib
             }
             return dict;
         }
+
+        public static bool CycleTime(this Message message, out int cycleTime)
+        {
+            if (message.CustomProperties.TryGetValue("GenMsgCycleTime", out var property))
+            {
+                cycleTime = property.IntegerCustomProperty.Value;
+                return true;
+            }
+            else
+            {
+                cycleTime = 0;
+                return false;
+            }
+        }
     }
 }

--- a/DbcParserLib/ExtensionsAndHelpers.cs
+++ b/DbcParserLib/ExtensionsAndHelpers.cs
@@ -2,7 +2,6 @@ using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using DbcParserLib.Model;
-using System;
 
 namespace DbcParserLib
 {
@@ -31,12 +30,6 @@ namespace DbcParserLib
         internal static ulong BitMask(this Signal signal)
         {
             return (ulong.MaxValue >> (64 - signal.Length));
-        }
-
-        [Obsolete("Please use ValueTableMap instead. ToPairs() and ValueTable will be removed in future releases")]
-        public static IEnumerable<KeyValuePair<int, string>> ToPairs(this Signal signal)
-        {
-            return signal.ValueTableMap;
         }
 
         private const string MultiplexorLabel = "M";

--- a/DbcParserLib/IDbcBuilder.cs
+++ b/DbcParserLib/IDbcBuilder.cs
@@ -7,7 +7,6 @@ namespace DbcParserLib
     {
         void AddMessage(Message message);
         void AddMessageComment(uint messageId, string comment);
-        void AddMessageCycleTime(uint messageId, int cycleTime);
         void AddNamedValueTable(string name, IReadOnlyDictionary<int, string> dictValues, string stringValues);
         void AddNode(Node node);
         void AddNodeComment(string nodeName, string comment);

--- a/DbcParserLib/IDbcBuilder.cs
+++ b/DbcParserLib/IDbcBuilder.cs
@@ -12,7 +12,6 @@ namespace DbcParserLib
         void AddNodeComment(string nodeName, string comment);
         void AddSignal(Signal signal);
         void AddSignalComment(uint messageId, string signalName, string comment);
-        void AddSignalInitialValue(uint messageId, string signalName, double initialValue);
         void AddSignalValueType(uint messageId, string signalName, DbcValueType valueType);
         void LinkNamedTableToSignal(uint messageId, string signalName, string tableName);
         void LinkTableValuesToSignal(uint messageId, string signalName, IReadOnlyDictionary<int, string> dictValues, string stringValues);

--- a/DbcParserLib/Model/CustomProperty.cs
+++ b/DbcParserLib/Model/CustomProperty.cs
@@ -14,13 +14,13 @@
             CustomPropertyDefinition = customPropertyDefinition;
         }
 
-        public void SetCustomPropertyValue(string value, bool isNumeric)
+        public bool SetCustomPropertyValue(string value, bool isNumeric)
         {
             switch (CustomPropertyDefinition.DataType)
             {
                 case CustomPropertyDataType.Integer:
                     if(!CustomPropertyDefinition.TryGetIntegerValue(value, isNumeric, out var integerValue))
-                        return;
+                        return false;
 
                     IntegerCustomProperty = new CustomPropertyValue<int>()
                     {
@@ -30,7 +30,7 @@
 
                 case CustomPropertyDataType.Hex:
                     if(!CustomPropertyDefinition.TryGetHexValue(value, isNumeric, out var hexValue))
-                        return;
+                        return false;
 
                     HexCustomProperty = new CustomPropertyValue<int>()
                     {
@@ -40,7 +40,7 @@
 
                 case CustomPropertyDataType.Float:
                     if(!CustomPropertyDefinition.TryGetFloatValue(value, isNumeric, out var floatValue))
-                        return;
+                        return false;
                     FloatCustomProperty = new CustomPropertyValue<double>()
                     {
                         Value = floatValue
@@ -49,7 +49,7 @@
 
                 case CustomPropertyDataType.String:
                     if(!CustomPropertyDefinition.IsString(isNumeric))
-                        return;
+                        return false;
                     StringCustomProperty = new CustomPropertyValue<string>()
                     {
                         Value = value
@@ -58,7 +58,7 @@
 
                 case CustomPropertyDataType.Enum:
                     if(!CustomPropertyDefinition.TryGetEnumValue(value, isNumeric, out var enumValue))
-                        return;
+                        return false;
 
                     EnumCustomProperty = new CustomPropertyValue<string>()
                     {
@@ -66,6 +66,7 @@
                     };
                     break;
             }
+            return true;
         }
 
         public void SetCustomPropertyValueFromDefault()

--- a/DbcParserLib/Model/CustomPropertyDefinition.cs
+++ b/DbcParserLib/Model/CustomPropertyDefinition.cs
@@ -20,7 +20,6 @@ namespace DbcParserLib.Model
             m_observer = observer;
         }
 
-
         public void SetCustomPropertyDefaultValue(string value, bool isNumeric)
         {
             switch (DataType)

--- a/DbcParserLib/Model/Message.cs
+++ b/DbcParserLib/Model/Message.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace DbcParserLib.Model
 {
@@ -37,7 +38,16 @@ namespace DbcParserLib.Model
         public ushort DLC;
         public string Transmitter;
         public string Comment;
-        public int CycleTime;
+        [Obsolete("Please use CycleTime(out int cycleTime) instead. CycleTime property will be removed and will be accessible only through extension method")]
+        public int CycleTime
+        {
+            get
+            {
+                this.CycleTime(out var cycleTime);
+                return cycleTime;
+            }
+        }
+
         public List<Signal> Signals = new List<Signal>();
         public IDictionary<string, CustomProperty> CustomProperties = new Dictionary<string, CustomProperty>();
 

--- a/DbcParserLib/Model/Signal.cs
+++ b/DbcParserLib/Model/Signal.cs
@@ -78,7 +78,16 @@ namespace DbcParserLib.Model
                 IsSigned = (byte)(value == DbcValueType.Unsigned ? 0 : 1);
             }
         }
-        public double InitialValue;
+
+        public double InitialValue
+        {
+            get
+            {
+                this.InitialValue(out var initialValue);
+                return initialValue;
+            }
+        }
+
         public double Factor = 1;
         public bool IsInteger = false;
         public double Offset;

--- a/DbcParserLib/Model/Signal.cs
+++ b/DbcParserLib/Model/Signal.cs
@@ -57,7 +57,7 @@ namespace DbcParserLib.Model
 
     public class Signal
     {
-        private DbcValueType m_ValueType = DbcValueType.Signed;
+        private DbcValueType m_valueType = DbcValueType.Signed;
 
         public uint ID;
         public string Name;
@@ -68,13 +68,10 @@ namespace DbcParserLib.Model
         public byte IsSigned { get; private set; } = 1;
         public DbcValueType ValueType
         {
-            get
-            {
-                return m_ValueType;
-            }
+            get => m_valueType;
             set
             {
-                m_ValueType = value;
+                m_valueType = value;
                 IsSigned = (byte)(value == DbcValueType.Unsigned ? 0 : 1);
             }
         }

--- a/DbcParserLib/Parsers/PropertiesLineParser.cs
+++ b/DbcParserLib/Parsers/PropertiesLineParser.cs
@@ -36,11 +36,7 @@ namespace DbcParserLib.Parsers
                 else if (match.Groups[4].Value == "BO_")
                     builder.AddMessageCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture), stringValue, isNumeric);
                 else if (match.Groups[6].Value == "SG_")
-                {
                     builder.AddSignalCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture), match.Groups[8].Value, stringValue, isNumeric);
-                    if (match.Groups[1].Value == "GenSigStartValue")
-                        builder.AddSignalInitialValue(uint.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture), match.Groups[8].Value, double.Parse(match.Groups[9].Value, CultureInfo.InvariantCulture));
-                }
             }
             else
                 m_observer.PropertySyntaxError();

--- a/DbcParserLib/Parsers/PropertiesLineParser.cs
+++ b/DbcParserLib/Parsers/PropertiesLineParser.cs
@@ -34,11 +34,7 @@ namespace DbcParserLib.Parsers
                 else if (match.Groups[2].Value == "EV_")
                     builder.AddEnvironmentVariableCustomProperty(match.Groups[1].Value, match.Groups[3].Value, stringValue, isNumeric);
                 else if (match.Groups[4].Value == "BO_")
-                {
                     builder.AddMessageCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture), stringValue, isNumeric);
-                    if (match.Groups[1].Value == "GenMsgCycleTime")
-                        builder.AddMessageCycleTime(uint.Parse(match.Groups[5].Value, CultureInfo.InvariantCulture), int.Parse(match.Groups[9].Value, CultureInfo.InvariantCulture));
-                }
                 else if (match.Groups[6].Value == "SG_")
                 {
                     builder.AddSignalCustomProperty(match.Groups[1].Value, uint.Parse(match.Groups[7].Value, CultureInfo.InvariantCulture), match.Groups[8].Value, stringValue, isNumeric);

--- a/README.md
+++ b/README.md
@@ -40,6 +40,30 @@ var filteredSelection = dbc
 			.ToArray();
 ```
 
+### Parsing errors management
+From **v1.4.0** parsing errors management has been introduced to inform users about syntax errors occurred during parsing procedure.
+The `IParseFailureObserver` interface provides all methods to handle syntax errors, like:
+- Generic syntax error (eg. `;`, `'`, `,` missing)
+- Duplicated object definition (eg. messages with same ID; nodes, signals, custom properties with same name etc..)
+- Object definition missing (eg. custom property is assigned before its declaration)
+- Value consistency (eg. custom property value is out of bound with respect to min and max values defined in the property)
+
+The library comes with two different implementations:
+1. `SilentFailureObserver`: the default one. It silently swallow errors when parsing
+2. `SimpleFailureObserver`: simple observer that logs any error. Errors list can be retrieve through `GetErrorList()` method, like in the example below
+
+```cs
+// Comment this two lines to remove errors parsing management (errors will be silent)
+// You can provide your own IParseFailureObserver implementation to customize errors parsing management
+var failureObserver = new SimpleFailureObserver();
+Parser.SetParsingFailuresObserver(failureObserver);
+
+var dbc = Parser.ParseFromPath(filePath);
+var errors = failureObserver.GetErrorList();
+```
+
+The user is free to create its own implementation to customize error management.
+
 ## Packing/Unpacking signals
 
 ### Simple scenario
@@ -103,6 +127,22 @@ if(message.IsMultiplexed())
 	// ...
 }
 ```
+
+<br>
+
+# Obsolete stuff
+
+Below you can find a list of obsolete stuff that are going to be removed in the future releases.
+
+| Class       | Property/Method     | Obsolete      | Removed               | Replaced by      | Comment       |
+| --------    | -------             | -------       | -------               | -------          | -------       |
+| Signal      | IsSigned            | v1.3.0        | planned in **1.4.3**  | `ValueType`      | Byte property replaced by `DbcValueType` property which provides <br> more informations about signal type |
+| Signal      | ValueTable          | v1.3.0        | planned in **1.4.3**  | `ValueTableMap`  | String property replaced by a `IDictionary<int,string>` property |
+| Signal      | ToPairs()           | v1.3.0        | **v1.4.2**            | -                | Extension method used to convert ValueTable into ValueTableMap |
+| Message     | CycleTime           | v1.4.2        | planned in **1.4.4**  | `CycleTime()`    | CycleTime is no more a message property (replaced by an extension method) |
+
+<br>
+
 # Useful references
 - [High level overview](https://docs.openvehicles.com/en/latest/components/vehicle_dbc/docs/dbc-primer.html)
 - [Very well done overview, many resources on that site](https://github.com/stefanhoelzl/CANpy/blob/master/docs/DBC_Specification.md)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Below you can find a list of obsolete stuff that are going to be removed in the 
 | Signal      | IsSigned            | v1.3.0        | planned in **1.4.3**  | `ValueType`      | Byte property replaced by `DbcValueType` property which provides <br> more informations about signal type |
 | Signal      | ValueTable          | v1.3.0        | planned in **1.4.3**  | `ValueTableMap`  | String property replaced by a `IDictionary<int,string>` property |
 | Signal      | ToPairs()           | v1.3.0        | **v1.4.2**            | -                | Extension method used to convert ValueTable into ValueTableMap |
-| Message     | CycleTime           | v1.4.2        | planned in **1.4.4**  | `CycleTime()`    | CycleTime is no more a message property (replaced by an extension method) |
+| Message     | CycleTime           | v1.4.2        | planned in **1.4.4**  | `bool CycleTime(out int cycleTime)`    | CycleTime is no more a message property (replaced by an extension method) |
 
 <br>
 


### PR DESCRIPTION
Taking as starting point the issue #43 the custom property parsing procedure has been changed to treat `GenMsgCycleTime` and `GenSigIntialValue` property as "normal" custom properties. Main changes:

- Message property CycleTime marked as obsolete. Added extension method to get `GenMsgCycleTime` property value from custom properties dictionary, if any.
- Signal property InitialValue now gets its value from InitialValue() extension method looking for `GenSigInitialValue` property value from custom properties dictionary, if any.
- Removed obsolete stuff
- Updated and added some tests
- Updated README: added `Parsing error management` chapter and `Obsolete stuff` chapter