### PR TITLE
Allow ValueTableLineParser to handle the case of (number " ") without…

### DIFF
--- a/DbcParserLib/Parsers/ValueTableLineParser.cs
+++ b/DbcParserLib/Parsers/ValueTableLineParser.cs
@@ -9,6 +9,8 @@ namespace DbcParserLib.Parsers
         private const string ValueTableLineStarter = "VAL_ ";
         private const string ValueTableLinkParsingRegex = @"VAL_\s+(\d+)\s+([a-zA-Z_][\w]*)\s+([a-zA-Z_][\w]*)\s*;";
         private const string ValueTableParsingRegex = @"VAL_\s+(?:(?:(\d+)\s+([a-zA-Z_][\w]*))|([a-zA-Z_][\w]*))\s+((?:(?:-?\d+)\s+(?:""[^""]*"")\s+)*)\s*;";
+        private const string ValueTableNewLineRegex = @"(""[^""]*""\s+)";
+        private const string ValueTableNewLineRegexReplace = "$1\n";
 
         private readonly IParseFailureObserver m_observer;
 
@@ -34,7 +36,7 @@ namespace DbcParserLib.Parsers
             match = Regex.Match(cleanLine, ValueTableParsingRegex);
             if (match.Success)
             {
-                var valueTable = match.Groups[4].Value.TrimStart().Replace("\" ", "\"" + Environment.NewLine);
+                var valueTable = Regex.Replace(match.Groups[4].Value.TrimStart(), ValueTableNewLineRegex, ValueTableNewLineRegexReplace);
                 var valueTableDictionary = valueTable.ToDictionary();
                 if (match.Groups[3].Value != "")
                     builder.LinkTableValuesToEnvironmentVariable(match.Groups[3].Value, valueTableDictionary);


### PR DESCRIPTION
… breaking the quotes onto multiple lines and then failing to build a dictionary after.

Before this change 

72 "H" 33 "!" 32 " " ;
Gets broken up into
72 "H"
33 "!"
32 "
"
Instead of what it should be:
72 "H"
33 "!"
32 " "