### PR TITLE
Removed obsolete property CycleTime

### DIFF
--- a/DbcParserLib.Tests/PropertiesLineParserTests.cs
+++ b/DbcParserLib.Tests/PropertiesLineParserTests.cs
@@ -171,7 +171,6 @@ namespace DbcParserLib.Tests
 
             var dbc = builder.Build();
             Assert.AreEqual(true, dbc.Messages.First().CycleTime(out var cycleTime));
-            Assert.AreEqual(100, dbc.Messages.First().CycleTime);
             Assert.AreEqual(100, cycleTime);
         }
 

--- a/DbcParserLib/Model/Message.cs
+++ b/DbcParserLib/Model/Message.cs
@@ -17,14 +17,17 @@ namespace DbcParserLib.Model
 
         internal ImmutableMessage(Message message, IReadOnlyList<ImmutableSignal> signals)
         {
+            message.CycleTime(out var cycleTime);
+
             ID = message.ID;
             IsExtID = message.IsExtID;
             Name = message.Name;
             DLC = message.DLC;
             Transmitter = message.Transmitter;
             Comment = message.Comment;
-            CycleTime= message.CycleTime;
+            CycleTime = cycleTime;
             Signals = signals;
+
             //TODO: remove explicit cast (CustomProperty in Message class should be Dictionary instead IDictionary)
             CustomProperties = (IReadOnlyDictionary<string, CustomProperty>)message.CustomProperties;
         }
@@ -38,16 +41,7 @@ namespace DbcParserLib.Model
         public ushort DLC;
         public string Transmitter;
         public string Comment;
-        [Obsolete("Please use CycleTime(out int cycleTime) instead. CycleTime property will be removed and will be accessible only through extension method")]
-        public int CycleTime
-        {
-            get
-            {
-                this.CycleTime(out var cycleTime);
-                return cycleTime;
-            }
-        }
-
+        
         public List<Signal> Signals = new List<Signal>();
         public IDictionary<string, CustomProperty> CustomProperties = new Dictionary<string, CustomProperty>();
 

--- a/Demo/Form1.cs
+++ b/Demo/Form1.cs
@@ -126,7 +126,8 @@ namespace Demo
             dtMessages.Columns.Add("CycleTime");
             foreach (var msg in dbc.Messages)
             {
-                dtMessages.Rows.Add("0x" + msg.ID.ToString("X"), msg.Name, msg.DLC, msg.Transmitter, msg.CycleTime);
+                msg.CycleTime(out var cycleTime);
+                dtMessages.Rows.Add("0x" + msg.ID.ToString("X"), msg.Name, msg.DLC, msg.Transmitter, cycleTime);
             }
 
             // Signals

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Below you can find a list of obsolete stuff that are going to be removed in the 
 | Signal      | IsSigned            | v1.3.0        | **v1.5.0**            | `ValueType`      | Byte property replaced by `DbcValueType` property which provides <br> more informations about signal type |
 | Signal      | ValueTable          | v1.3.0        | **v1.5.0**            | `ValueTableMap`  | String property replaced by a `IDictionary<int,string>` property |
 | Signal      | ToPairs()           | v1.3.0        | **v1.4.2**            | -                | Extension method used to convert ValueTable into ValueTableMap |
-| Message     | CycleTime           | v1.4.2        | planned in **1.6.0**  | `bool CycleTime(out int cycleTime)`    | CycleTime is no more a message property (replaced by an extension method) |
+| Message     | CycleTime           | v1.4.2        | **1.6.0**             | `bool CycleTime(out int cycleTime)`    | CycleTime is no more a message property (replaced by an extension method) |
 
 <br>
 


### PR DESCRIPTION
CycleTime is no more a message property (replaced by an extension method). 
Updated README.md