### PR TITLE
#65 ignore min/max values of CustomAttributes when both are set to 0

### DIFF
--- a/DbcParserLib.Tests/PropertiesLineParserTests.cs
+++ b/DbcParserLib.Tests/PropertiesLineParserTests.cs
@@ -56,6 +56,52 @@ namespace DbcParserLib.Tests
         }
 
         [Test]
+        public void IntDefinitionCustomPropertyNoBoundariesIsParsedTest()
+        {
+            var builder = new DbcBuilder(new SilentFailureObserver());
+            var message = new Message { ID = 2394947585 };
+            builder.AddMessage(message);
+
+            var msgCycleTimeLineParser = CreateParser();
+            var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
+            Assert.IsTrue(ParseLine(@"BA_DEF_ BO_ ""AttributeName"" INT 0 0;", msgCycleTimeLineParser, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" 150;", msgCycleTimeLineParser, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_ ""AttributeName"" BO_ 2394947585 100;", msgCycleTimeLineParser, builder, nextLineProvider));
+
+            var dbc = builder.Build();
+            Assert.AreEqual(true, dbc.Messages.First().CustomProperties.TryGetValue("AttributeName", out var customProperty));
+            Assert.AreEqual(100, customProperty!.IntegerCustomProperty.Value);
+        }
+
+        [Test]
+        public void HexDefinitionCustomPropertyIsParsedTest()
+        {
+            var builder = new DbcBuilder(new SilentFailureObserver());
+
+            var customPropertyLineParsers = CreateParser();
+            var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
+            Assert.IsTrue(ParseLine(@"BA_DEF_ BU_ ""AttributeName"" HEX 5 10;", customPropertyLineParsers, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" 7;", customPropertyLineParsers, builder, nextLineProvider));
+        }
+
+        [Test]
+        public void HexDefinitionCustomPropertyNoBoundariesIsParsedTest()
+        {
+            var builder = new DbcBuilder(new SilentFailureObserver());
+            var message = new Message { ID = 2394947585 };
+            builder.AddMessage(message);
+
+            var msgCycleTimeLineParser = CreateParser();
+            var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
+            Assert.IsTrue(ParseLine(@"BA_DEF_ BO_ ""AttributeName"" HEX 0 0;", msgCycleTimeLineParser, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" 150;", msgCycleTimeLineParser, builder, nextLineProvider));
+
+            var dbc = builder.Build();
+            Assert.AreEqual(true, dbc.Messages.First().CustomProperties.TryGetValue("AttributeName", out var customProperty));
+            Assert.AreEqual(150, customProperty!.HexCustomProperty.Value);
+        }
+
+        [Test]
         public void FloatDefinitionCustomPropertyIsParsedTest()
         {
             var builder = new DbcBuilder(new SilentFailureObserver());
@@ -64,6 +110,23 @@ namespace DbcParserLib.Tests
             var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
             Assert.IsTrue(ParseLine(@"BA_DEF_ BU_ ""AttributeName"" FLOAT 5 10.5;", customPropertyLineParsers, builder, nextLineProvider));
             Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" 7.5;", customPropertyLineParsers, builder, nextLineProvider));
+        }
+
+        [Test]
+        public void FloatDefinitionCustomPropertyNoBoundariesIsParsedTest()
+        {
+            var builder = new DbcBuilder(new SilentFailureObserver());
+            var message = new Message { ID = 2394947585 };
+            builder.AddMessage(message);
+
+            var msgCycleTimeLineParser = CreateParser();
+            var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
+            Assert.IsTrue(ParseLine(@"BA_DEF_ BO_ ""AttributeName"" FLOAT 0 0;", msgCycleTimeLineParser, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""AttributeName"" 150.0;", msgCycleTimeLineParser, builder, nextLineProvider));
+
+            var dbc = builder.Build();
+            Assert.AreEqual(true, dbc.Messages.First().CustomProperties.TryGetValue("AttributeName", out var customProperty));
+            Assert.AreEqual(150, customProperty!.FloatCustomProperty.Value);
         }
 
         [Test]
@@ -165,7 +228,7 @@ namespace DbcParserLib.Tests
 
             var msgCycleTimeLineParser = CreateParser();
             var nextLineProvider = new NextLineProvider(new StringReader(string.Empty));
-            Assert.IsTrue(ParseLine(@"BA_DEF_ BO_ ""GenMsgCycleTime"" INT 0 200;", msgCycleTimeLineParser, builder, nextLineProvider));
+            Assert.IsTrue(ParseLine(@"BA_DEF_ BO_ ""GenMsgCycleTime"" INT 0 0;", msgCycleTimeLineParser, builder, nextLineProvider));
             Assert.IsTrue(ParseLine(@"BA_DEF_DEF_ ""GenMsgCycleTime"" 150;", msgCycleTimeLineParser, builder, nextLineProvider));
             Assert.IsTrue(ParseLine(@"BA_ ""GenMsgCycleTime"" BO_ 2394947585 100;", msgCycleTimeLineParser, builder, nextLineProvider));
 

--- a/DbcParserLib/DbcParserLib.csproj
+++ b/DbcParserLib/DbcParserLib.csproj
@@ -13,7 +13,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <PackageReleaseNotes></PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/DbcParserLib/ExtensionsAndHelpers.cs
+++ b/DbcParserLib/ExtensionsAndHelpers.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using DbcParserLib.Model;
-using System.Text;
 
 namespace DbcParserLib
 {

--- a/DbcParserLib/Model/CustomPropertyDefinition.cs
+++ b/DbcParserLib/Model/CustomPropertyDefinition.cs
@@ -72,6 +72,9 @@ namespace DbcParserLib.Model
                 return false;
             }
 
+            if (CanAcceptAllValue(CustomPropertyDataType.Integer))
+                return true;
+
             if (integerValue < IntegerCustomProperty.Minimum || integerValue > IntegerCustomProperty.Maximum)
             {
                 m_observer.PropertyValueOutOfBound(Name, value);
@@ -97,6 +100,9 @@ namespace DbcParserLib.Model
                 return false;
             }
 
+            if (CanAcceptAllValue(CustomPropertyDataType.Hex))
+                return true;
+
             if (hexValue < HexCustomProperty.Minimum || hexValue > HexCustomProperty.Maximum)
             {
                 m_observer.PropertyValueOutOfBound(Name, value);
@@ -121,6 +127,9 @@ namespace DbcParserLib.Model
                 m_observer.PropertySyntaxError();
                 return false;
             }
+            
+            if (CanAcceptAllValue(CustomPropertyDataType.Float))
+                return true;
 
             if (floatValue < FloatCustomProperty.Minimum || floatValue > FloatCustomProperty.Maximum)
             {
@@ -182,6 +191,23 @@ namespace DbcParserLib.Model
             
             enumValue = EnumCustomProperty.Values[index];
             return true;
+        }
+
+        private bool CanAcceptAllValue(CustomPropertyDataType dataType)
+        {
+            switch (dataType)
+            {
+                case CustomPropertyDataType.Integer:
+                    return IntegerCustomProperty.Minimum == 0 && IntegerCustomProperty.Maximum == 0;
+                case CustomPropertyDataType.Hex:
+                    return HexCustomProperty.Minimum == 0 && HexCustomProperty.Maximum == 0;
+                case CustomPropertyDataType.Float:
+                    return FloatCustomProperty.Minimum == 0 && FloatCustomProperty.Maximum == 0;
+                case CustomPropertyDataType.String:
+                case CustomPropertyDataType.Enum:
+                default:
+                    return false;
+            }
         }
     }
 

--- a/DbcParserLib/Model/Message.cs
+++ b/DbcParserLib/Model/Message.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace DbcParserLib.Model
 {

--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -1,9 +1,4 @@
-using int8_T = System.SByte;
 using uint8_T = System.Byte;
-using int16_T = System.Int16;
-using uint16_T = System.UInt16;
-using int32_T = System.Int32;
-using uint32_T = System.UInt32;
 using int64_T = System.Int64;
 using uint64_T = System.UInt64;
 using System;


### PR DESCRIPTION
- Custom property definition now skips input validation if both min and max values are set to zero (accept all values)
- Added some tests
- Code cleanup