### PR TITLE
#67 Functions for unpacking based on byte arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.suo
 *.user
 *.sln.docstates
+.idea
 .vs
 
 # Build results

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ DbcParserLib/obj/
 DbcParserLib/bin/
 DbcParserLib.Tests/obj/
 DbcParserLib.Tests/bin/
+DbcParserLib.Benchmarks/obj/
+DbcParserLib.Benchmarks/bin/
 Demo/obj/
 Demo/bin/
 

--- a/DbcParser.sln
+++ b/DbcParser.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31515.178
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34607.119
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbcParserLib", "DbcParserLib\DbcParserLib.csproj", "{82DD10F6-784A-4D87-B117-FB910E84D175}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Demo", "Demo\Demo.csproj", "{9CA98991-90EF-4E86-BCA6-372EF2AE471E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbcParserLib.Tests", "DbcParserLib.Tests\DbcParserLib.Tests.csproj", "{0FE933E2-4870-49BD-9A9A-931F30730D82}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbcParserLib.Tests", "DbcParserLib.Tests\DbcParserLib.Tests.csproj", "{0FE933E2-4870-49BD-9A9A-931F30730D82}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbcParserLib.Benchmarks", "DbcParserLib.Benchmarks\DbcParserLib.Benchmarks.csproj", "{0B3323E7-FEC3-4606-9012-C6166D941CCC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{0FE933E2-4870-49BD-9A9A-931F30730D82}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0FE933E2-4870-49BD-9A9A-931F30730D82}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0FE933E2-4870-49BD-9A9A-931F30730D82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B3323E7-FEC3-4606-9012-C6166D941CCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B3323E7-FEC3-4606-9012-C6166D941CCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B3323E7-FEC3-4606-9012-C6166D941CCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B3323E7-FEC3-4606-9012-C6166D941CCC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DbcParserLib.Benchmarks/DbcParserLib.Benchmarks.csproj
+++ b/DbcParserLib.Benchmarks/DbcParserLib.Benchmarks.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\DbcParserLib\DbcParserLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DbcParserLib.Benchmarks/PackerBenchmark.cs
+++ b/DbcParserLib.Benchmarks/PackerBenchmark.cs
@@ -126,10 +126,10 @@ namespace DbcParserLib.Tests
         public byte[] Pack_8Byte_BigEndian_ByteArray()
         {
             byte[] TxMsg = new byte[8];
-            Packer.TxSignalPack(ref TxMsg, 0, EightByte_BigEndian_Signal1);
-            Packer.TxSignalPack(ref TxMsg, 63, EightByte_BigEndian_Signal2);
-            Packer.TxSignalPack(ref TxMsg, 0, EightByte_BigEndian_Signal3);
-            Packer.TxSignalPack(ref TxMsg, ushort.MaxValue, EightByte_BigEndian_Signal4);
+            Packer.TxSignalPack(TxMsg, 0, EightByte_BigEndian_Signal1);
+            Packer.TxSignalPack(TxMsg, 63, EightByte_BigEndian_Signal2);
+            Packer.TxSignalPack(TxMsg, 0, EightByte_BigEndian_Signal3);
+            Packer.TxSignalPack(TxMsg, ushort.MaxValue, EightByte_BigEndian_Signal4);
             return TxMsg;
         }
 
@@ -148,10 +148,10 @@ namespace DbcParserLib.Tests
         public byte[] Pack_8Byte_LittleEndian_ByteArray()
         {
             byte[] TxMsg = new byte[8];
-            Packer.TxSignalPack(ref TxMsg, 0, EightByte_LittleEndian_Signal1);
-            Packer.TxSignalPack(ref TxMsg, 63, EightByte_LittleEndian_Signal2);
-            Packer.TxSignalPack(ref TxMsg, 0, EightByte_LittleEndian_Signal3);
-            Packer.TxSignalPack(ref TxMsg, ushort.MaxValue, EightByte_LittleEndian_Signal4);
+            Packer.TxSignalPack(TxMsg, 0, EightByte_LittleEndian_Signal1);
+            Packer.TxSignalPack(TxMsg, 63, EightByte_LittleEndian_Signal2);
+            Packer.TxSignalPack(TxMsg, 0, EightByte_LittleEndian_Signal3);
+            Packer.TxSignalPack(TxMsg, ushort.MaxValue, EightByte_LittleEndian_Signal4);
             return TxMsg;
         }
 
@@ -175,7 +175,7 @@ namespace DbcParserLib.Tests
         public byte[] Pack_1Signal_Unsigned_NoScale_SignalPackByteArray()
         {
             byte[] TxMsg = new byte[8];
-            Packer.TxSignalPack(ref TxMsg, 123, LittleEndian_Unsigned_NoScale);
+            Packer.TxSignalPack(TxMsg, 123, LittleEndian_Unsigned_NoScale);
             return TxMsg;
         }
     }

--- a/DbcParserLib.Benchmarks/PackerBenchmark.cs
+++ b/DbcParserLib.Benchmarks/PackerBenchmark.cs
@@ -1,0 +1,79 @@
+using DbcParserLib.Model;
+using BenchmarkDotNet.Attributes;
+
+namespace DbcParserLib.Tests
+{
+    public class PackerBenchmark
+    {
+        private Signal EightByte_BigEndian_Signal1;
+        private Signal EightByte_BigEndian_Signal2;
+        private Signal EightByte_BigEndian_Signal3;
+        private Signal EightByte_BigEndian_Signal4;
+
+        [GlobalSetup]
+        public void SetupSignals()
+        {
+            EightByte_BigEndian_Signal1 = new Signal
+            {
+                StartBit = 7,
+                Length = 10,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+
+            EightByte_BigEndian_Signal2 = new Signal
+            {
+                StartBit = 13,
+                Length = 6,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+
+            EightByte_BigEndian_Signal3 = new Signal
+            {
+                StartBit = 23,
+                Length = 32,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+
+            EightByte_BigEndian_Signal4 = new Signal
+            {
+                StartBit = 55,
+                Length = 16,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+        }
+
+        [Benchmark]
+        public ulong Pack_8Byte_BigEndian_Uint64()
+        {
+            ulong TxMsg = 0;
+            TxMsg |= Packer.TxSignalPack(0, EightByte_BigEndian_Signal1);
+            TxMsg |= Packer.TxSignalPack(63, EightByte_BigEndian_Signal2);
+            TxMsg |= Packer.TxSignalPack(0, EightByte_BigEndian_Signal3);
+            TxMsg |= Packer.TxSignalPack(ushort.MaxValue, EightByte_BigEndian_Signal4);
+            return TxMsg;   
+        }
+
+        [Benchmark]
+        public ulong Pack_8Byte_BigEndian_ByteArray()
+        {
+            ulong TxMsg = 0;
+            TxMsg |= Packer.TxSignalPack(0, EightByte_BigEndian_Signal1);
+            TxMsg |= Packer.TxSignalPack(63, EightByte_BigEndian_Signal2);
+            TxMsg |= Packer.TxSignalPack(0, EightByte_BigEndian_Signal3);
+            TxMsg |= Packer.TxSignalPack(ushort.MaxValue, EightByte_BigEndian_Signal4);
+            return TxMsg;
+        }
+    }
+}

--- a/DbcParserLib.Benchmarks/PackerBenchmark.cs
+++ b/DbcParserLib.Benchmarks/PackerBenchmark.cs
@@ -172,10 +172,11 @@ namespace DbcParserLib.Tests
         }
 
         [Benchmark]
-        public void Pack_1Signal_Unsigned_NoScale_SignalPackByteArray()
+        public byte[] Pack_1Signal_Unsigned_NoScale_SignalPackByteArray()
         {
             byte[] TxMsg = new byte[8];
             Packer.TxSignalPack(ref TxMsg, 123, LittleEndian_Unsigned_NoScale);
+            return TxMsg;
         }
     }
 }

--- a/DbcParserLib.Benchmarks/Program.cs
+++ b/DbcParserLib.Benchmarks/Program.cs
@@ -23,4 +23,24 @@ AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
 | Pack_1Signal_Unsigned_NoScale_SignalPackByteArray | 49.3012 ns | 0.8965 ns | 0.8386 ns |
 */
 
-//var summaryUnpack = BenchmarkRunner.Run<UnpackBenchmark>();
+var summaryUnpack = BenchmarkRunner.Run<UnpackBenchmark>();
+
+/* Summary => This is pc dependend. The relevant information is the time difference
+
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.3880/23H2/2023Update/SunValley3)
+AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
+.NET SDK 8.0.200
+  [Host]     : .NET 6.0.32 (6.0.3224.31407), X64 RyuJIT AVX2
+  DefaultJob : .NET 6.0.32 (6.0.3224.31407), X64 RyuJIT AVX2
+
+
+| Method                                          | Mean       | Error     | StdDev    |
+|------------------------------------------------ |-----------:| ----------:| ----------:|
+| Unpack_8Byte_BigEndian_Uint64                   | 107.287 ns | 2.1000 ns | 2.0625 ns |
+| Unpack_8Byte_BigEndian_ByteArray                | 201.915 ns | 4.0086 ns | 4.2892 ns |
+| Unpack_8Byte_LittleEndian_Uint64                | 81.062 ns | 0.2072 ns | 0.1617 ns |
+| Unpack_8Byte_LittleEndian_ByteArray             | 171.328 ns | 3.2070 ns | 3.1497 ns |
+| Unpack_1Signal_Unsigned_NoScale_State           | 1.077 ns | 0.0037 ns | 0.0029 ns |
+| Unpack_1Signal_Unsigned_NoScale_Signal          | 20.269 ns | 0.1389 ns | 0.1232 ns |
+| Unpack_1Signal_Unsigned_NoScale_SignalByteArray | 62.919 ns | 0.1156 ns | 0.0902 ns |
+*/

--- a/DbcParserLib.Benchmarks/Program.cs
+++ b/DbcParserLib.Benchmarks/Program.cs
@@ -1,10 +1,9 @@
 ﻿using BenchmarkDotNet.Running;
 using DbcParserLib.Tests;
 
-var summary = BenchmarkRunner.Run<PackerBenchmark>();
+var summaryPack = BenchmarkRunner.Run<PackerBenchmark>();
 
-
-/* Summary 
+/* Summary => This is pc dependend. The relevant information is the time difference
 
 BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.3880/23H2/2023Update/SunValley3)
 AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
@@ -13,9 +12,15 @@ AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
   DefaultJob : .NET 6.0.32 (6.0.3224.31407), X64 RyuJIT AVX2
 
 
-| Method                         | Mean     | Error    | StdDev   |
-|------------------------------- |---------:| --------:| --------:|
-| Pack_8Byte_BigEndian_Uint64    | 40.24 ns | 0.555 ns | 0.519 ns |
-| Pack_8Byte_BigEndian_ByteArray | 39.68 ns | 0.786 ns | 0.807 ns |
-
+| Method                                            | Mean        | Error     | StdDev    |
+|-------------------------------------------------- |------------:| ----------:| ----------:|
+| Pack_8Byte_BigEndian_Uint64                       | 40.5778 ns | 0.3100 ns | 0.2420 ns |
+| Pack_8Byte_BigEndian_ByteArray                    | 167.4555 ns | 2.3924 ns | 2.2379 ns |
+| Pack_8Byte_LittleEndian_Uint64                    | 12.1883 ns | 0.1173 ns | 0.0980 ns |
+| Pack_8Byte_LittleEndian_ByteArray                 | 100.1948 ns | 0.6864 ns | 0.5359 ns |
+| Pack_1Signal_Unsigned_NoScale_StatePack           | 0.8825 ns | 0.0081 ns | 0.0068 ns |
+| Pack_1Signal_Unsigned_NoScale_SignalPack          | 3.0999 ns | 0.0711 ns | 0.0665 ns |
+| Pack_1Signal_Unsigned_NoScale_SignalPackByteArray | 49.3012 ns | 0.8965 ns | 0.8386 ns |
 */
+
+//var summaryUnpack = BenchmarkRunner.Run<UnpackBenchmark>();

--- a/DbcParserLib.Benchmarks/Program.cs
+++ b/DbcParserLib.Benchmarks/Program.cs
@@ -1,0 +1,21 @@
+﻿using BenchmarkDotNet.Running;
+using DbcParserLib.Tests;
+
+var summary = BenchmarkRunner.Run<PackerBenchmark>();
+
+
+/* Summary 
+
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.3880/23H2/2023Update/SunValley3)
+AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
+.NET SDK 8.0.200
+  [Host]     : .NET 6.0.32 (6.0.3224.31407), X64 RyuJIT AVX2
+  DefaultJob : .NET 6.0.32 (6.0.3224.31407), X64 RyuJIT AVX2
+
+
+| Method                         | Mean     | Error    | StdDev   |
+|------------------------------- |---------:| --------:| --------:|
+| Pack_8Byte_BigEndian_Uint64    | 40.24 ns | 0.555 ns | 0.519 ns |
+| Pack_8Byte_BigEndian_ByteArray | 39.68 ns | 0.786 ns | 0.807 ns |
+
+*/

--- a/DbcParserLib.Benchmarks/Program.cs
+++ b/DbcParserLib.Benchmarks/Program.cs
@@ -15,7 +15,7 @@ AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
 | Method                                            | Mean        | Error     | StdDev    |
 |-------------------------------------------------- |------------:| ----------:| ----------:|
 | Pack_8Byte_BigEndian_Uint64                       | 40.5778 ns | 0.3100 ns | 0.2420 ns |
-| Pack_8Byte_BigEndian_ByteArray                    | 167.4555 ns | 2.3924 ns | 2.2379 ns |
+| Pack_8Byte_BigEndian_ByteArray                    | 126.9214 ns | 2.5612 ns | 2.3958 ns |
 | Pack_8Byte_LittleEndian_Uint64                    | 12.1883 ns | 0.1173 ns | 0.0980 ns |
 | Pack_8Byte_LittleEndian_ByteArray                 | 100.1948 ns | 0.6864 ns | 0.5359 ns |
 | Pack_1Signal_Unsigned_NoScale_StatePack           | 0.8825 ns | 0.0081 ns | 0.0068 ns |

--- a/DbcParserLib.Benchmarks/UnpackBenchmark.cs
+++ b/DbcParserLib.Benchmarks/UnpackBenchmark.cs
@@ -17,6 +17,9 @@ namespace DbcParserLib.Tests
 
         private Signal LittleEndian_Unsigned_NoScale;
 
+        private ulong RxMsg = ulong.MaxValue;
+        private byte[] RxBytes = new byte[] { byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue };
+
         [GlobalSetup]
         public void SetupSignals()
         {
@@ -112,70 +115,57 @@ namespace DbcParserLib.Tests
         }
 
         [Benchmark]
-        public ulong Pack_8Byte_BigEndian_Uint64()
+        public void Unpack_8Byte_BigEndian_Uint64()
         {
-            ulong TxMsg = 0;
-            TxMsg |= Packer.TxSignalPack(0, EightByte_BigEndian_Signal1);
-            TxMsg |= Packer.TxSignalPack(63, EightByte_BigEndian_Signal2);
-            TxMsg |= Packer.TxSignalPack(0, EightByte_BigEndian_Signal3);
-            TxMsg |= Packer.TxSignalPack(ushort.MaxValue, EightByte_BigEndian_Signal4);
-            return TxMsg;   
+            var signal1 = Packer.RxSignalUnpack(RxMsg, EightByte_BigEndian_Signal1);
+            var signal2 = Packer.RxSignalUnpack(RxMsg, EightByte_BigEndian_Signal2);
+            var signal3 = Packer.RxSignalUnpack(RxMsg, EightByte_BigEndian_Signal3);
+            var signal4 = Packer.RxSignalUnpack(RxMsg, EightByte_BigEndian_Signal4);  
         }
 
         [Benchmark]
-        public byte[] Pack_8Byte_BigEndian_ByteArray()
+        public void Unpack_8Byte_BigEndian_ByteArray()
         {
-            byte[] TxMsg = new byte[8];
-            Packer.TxSignalPack(ref TxMsg, 0, EightByte_BigEndian_Signal1);
-            Packer.TxSignalPack(ref TxMsg, 63, EightByte_BigEndian_Signal2);
-            Packer.TxSignalPack(ref TxMsg, 0, EightByte_BigEndian_Signal3);
-            Packer.TxSignalPack(ref TxMsg, ushort.MaxValue, EightByte_BigEndian_Signal4);
-            return TxMsg;
+            var signal1 = Packer.RxSignalUnpack(RxBytes, EightByte_BigEndian_Signal1);
+            var signal2 = Packer.RxSignalUnpack(RxBytes, EightByte_BigEndian_Signal2);
+            var signal3 = Packer.RxSignalUnpack(RxBytes, EightByte_BigEndian_Signal3);
+            var signal4 = Packer.RxSignalUnpack(RxBytes, EightByte_BigEndian_Signal4);
         }
 
         [Benchmark]
-        public ulong Pack_8Byte_LittleEndian_Uint64()
+        public void Unpack_8Byte_LittleEndian_Uint64()
         {
-            ulong TxMsg = 0;
-            TxMsg |= Packer.TxSignalPack(0, EightByte_LittleEndian_Signal1);
-            TxMsg |= Packer.TxSignalPack(63, EightByte_LittleEndian_Signal2);
-            TxMsg |= Packer.TxSignalPack(0, EightByte_LittleEndian_Signal3);
-            TxMsg |= Packer.TxSignalPack(ushort.MaxValue, EightByte_LittleEndian_Signal4);
-            return TxMsg;
+            var signal1 = Packer.RxSignalUnpack(RxMsg, EightByte_LittleEndian_Signal1);
+            var signal2 = Packer.RxSignalUnpack(RxMsg, EightByte_LittleEndian_Signal2);
+            var signal3 = Packer.RxSignalUnpack(RxMsg, EightByte_LittleEndian_Signal3);
+            var signal4 = Packer.RxSignalUnpack(RxMsg, EightByte_LittleEndian_Signal4);
         }
 
         [Benchmark]
-        public byte[] Pack_8Byte_LittleEndian_ByteArray()
+        public void Unpack_8Byte_LittleEndian_ByteArray()
         {
-            byte[] TxMsg = new byte[8];
-            Packer.TxSignalPack(ref TxMsg, 0, EightByte_LittleEndian_Signal1);
-            Packer.TxSignalPack(ref TxMsg, 63, EightByte_LittleEndian_Signal2);
-            Packer.TxSignalPack(ref TxMsg, 0, EightByte_LittleEndian_Signal3);
-            Packer.TxSignalPack(ref TxMsg, ushort.MaxValue, EightByte_LittleEndian_Signal4);
-            return TxMsg;
+            var signal1 = Packer.RxSignalUnpack(RxBytes, EightByte_LittleEndian_Signal1);
+            var signal2 = Packer.RxSignalUnpack(RxBytes, EightByte_LittleEndian_Signal2);
+            var signal3 = Packer.RxSignalUnpack(RxBytes, EightByte_LittleEndian_Signal3);
+            var signal4 = Packer.RxSignalUnpack(RxBytes, EightByte_LittleEndian_Signal4);
         }
 
         [Benchmark]
-        public ulong Pack_1Signal_Unsigned_NoScale_StatePack()
+        public ulong Unpack_1Signal_Unsigned_NoScale_State()
         {
-            ulong TxMsg = 0;
-            TxMsg |= Packer.TxStatePack(123, LittleEndian_Unsigned_NoScale);
-            return TxMsg;
+            return Packer.RxStateUnpack(RxMsg, LittleEndian_Unsigned_NoScale);
         }
 
         [Benchmark]
-        public ulong Pack_1Signal_Unsigned_NoScale_SignalPack()
+        public double Unpack_1Signal_Unsigned_NoScale_Signal()
         {
-            ulong TxMsg = 0;
-            TxMsg |= Packer.TxSignalPack(123, LittleEndian_Unsigned_NoScale);
-            return TxMsg;
+            return Packer.RxSignalUnpack(RxMsg, LittleEndian_Unsigned_NoScale);
         }
 
         [Benchmark]
-        public void Pack_1Signal_Unsigned_NoScale_SignalPackByteArray()
+        public double Unpack_1Signal_Unsigned_NoScale_SignalByteArray()
         {
-            byte[] TxMsg = new byte[8];
-            Packer.TxSignalPack(ref TxMsg, 123, LittleEndian_Unsigned_NoScale);
+            return Packer.RxSignalUnpack(RxBytes, LittleEndian_Unsigned_NoScale);
         }
     }
 }

--- a/DbcParserLib.Benchmarks/UnpackBenchmark.cs
+++ b/DbcParserLib.Benchmarks/UnpackBenchmark.cs
@@ -3,7 +3,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace DbcParserLib.Tests
 {
-    public class PackerBenchmark
+    public class UnpackBenchmark
     {
         private Signal EightByte_BigEndian_Signal1;
         private Signal EightByte_BigEndian_Signal2;

--- a/DbcParserLib.Tests/PackerTests.cs
+++ b/DbcParserLib.Tests/PackerTests.cs
@@ -191,10 +191,10 @@ namespace DbcParserLib.Tests
             Assert.AreEqual(18446462598732857088, TxMsg);
 
             byte[] txMsg = new byte[8];
-            Packer.TxSignalPack(ref txMsg, 0, sig1);
-            Packer.TxSignalPack(ref txMsg, 63, sig2);
-            Packer.TxSignalPack(ref txMsg, 0, sig3);
-            Packer.TxSignalPack(ref txMsg, ushort.MaxValue, sig4);
+            Packer.TxSignalPack(txMsg, 0, sig1);
+            Packer.TxSignalPack(txMsg, 63, sig2);
+            Packer.TxSignalPack(txMsg, 0, sig3);
+            Packer.TxSignalPack(txMsg, ushort.MaxValue, sig4);
 
             Assert.AreEqual(18446462598732857088, BitConverter.ToUInt64(txMsg));
         }

--- a/DbcParserLib.Tests/PackerTests.cs
+++ b/DbcParserLib.Tests/PackerTests.cs
@@ -24,6 +24,14 @@ namespace DbcParserLib.Tests
 
             var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(-34.3, val, 1e-2);
+
+
+            var byteMsg = new byte[8];
+            Packer.TxSignalPack(byteMsg, - 34.3, sig);
+            Assert.AreEqual(43816, BitConverter.ToUInt64(byteMsg));
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(-34.3, valbyte, 1e-2);
         }
 
         [TestCase((ushort)0, 3255382835ul)]
@@ -48,6 +56,14 @@ namespace DbcParserLib.Tests
 
             var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(expected, val, 1e-2);
+
+
+            var byteMsg = new byte[8];
+            Packer.TxSignalPack(byteMsg, expected, sig);
+            Assert.AreEqual(packet, BitConverter.ToUInt64(byteMsg));
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(expected, valbyte, 1e-2);
         }
 
         [TestCase((ushort)0, 439799153665ul)]
@@ -72,6 +88,14 @@ namespace DbcParserLib.Tests
 
             var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(value, val, 1e-2);
+
+
+            var byteMsg = new byte[8];
+            Packer.TxSignalPack(byteMsg, value, sig);
+            Assert.AreEqual(packet, BitConverter.ToUInt64(byteMsg));
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(value, valbyte, 1e-2);
         }
 
         [Test]
@@ -93,6 +117,14 @@ namespace DbcParserLib.Tests
 
             var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(expected, val, 1e-2);
+
+
+            var byteMsg = new byte[8];
+            Packer.TxSignalPack(byteMsg, expected, sig);
+            Assert.AreEqual(13853404129830452697, BitConverter.ToUInt64(byteMsg));
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(expected, valbyte, 1e-2);
         }
 
         [Test]
@@ -114,6 +146,14 @@ namespace DbcParserLib.Tests
 
             var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(expected, val, 1e-2);
+
+
+            var byteMsg = new byte[8];
+            Packer.TxSignalPack(byteMsg, expected, sig);
+            Assert.AreEqual(2419432028705210816, BitConverter.ToUInt64(byteMsg));
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(expected, valbyte, 1e-2);
         }
 
         [Test]
@@ -190,6 +230,7 @@ namespace DbcParserLib.Tests
 
             Assert.AreEqual(18446462598732857088, TxMsg);
 
+
             byte[] txMsg = new byte[8];
             Packer.TxSignalPack(txMsg, 0, sig1);
             Packer.TxSignalPack(txMsg, 63, sig2);
@@ -217,6 +258,14 @@ namespace DbcParserLib.Tests
 
             var val = Packer.RxSignalUnpack(txMsg, sig);
             Assert.AreEqual(396.31676720860366, val);
+
+
+            var byteMsg = new byte[8];
+            Packer.TxSignalPack(byteMsg, 396.31676720860366, sig);
+            Assert.AreEqual(3963167672086036480, BitConverter.ToUInt64(byteMsg));
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(396.31676720860366, valbyte);
         }
 
         //Although Pack has one output per value/signal. Unpack can produce the same result for two different RxMsg64 inputs
@@ -241,6 +290,17 @@ namespace DbcParserLib.Tests
 
             val = Packer.RxSignalUnpack(9655716608953581040, sig);
             Assert.AreEqual(8, val);
+
+
+            var byteMsg = new byte[8];
+            Packer.TxSignalPack(byteMsg, 8, sig);
+            Assert.AreEqual(9583660007044415488, BitConverter.ToUInt64(byteMsg));
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(8, valbyte);
+
+            valbyte = Packer.RxSignalUnpack(BitConverter.GetBytes(9655716608953581040), sig);
+            Assert.AreEqual(8, valbyte);
         }
 
         //A bit packing test with a length of 1 (to test signals with < 8 bits)
@@ -265,11 +325,21 @@ namespace DbcParserLib.Tests
 
             val = Packer.RxSignalUnpack(140737488617472, sig);
             Assert.AreEqual(1, val);
+
+
+            var byteMsg = new byte[8];
+            Packer.TxSignalPack(byteMsg, 1, sig);
+            Assert.AreEqual(262144, BitConverter.ToUInt64(byteMsg));
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(1, valbyte);
+
+            valbyte = Packer.RxSignalUnpack(BitConverter.GetBytes(140737488617472), sig);
+            Assert.AreEqual(1, valbyte);
         }
 
-        //A bit packing test with a length of 3 (to test signals with < 8 bits)
         [Test]
-        public void BitPackingTest2()
+        public void UnsignedPackingTest()
         {
             var sig = new Signal
             {
@@ -289,6 +359,17 @@ namespace DbcParserLib.Tests
 
             val = Packer.RxSignalUnpack(498806260540323729, sig);
             Assert.AreEqual(6, val);
+
+
+            var byteMsg = new byte[8];
+            Packer.TxSignalPack(byteMsg, 6, sig);
+            Assert.AreEqual(384, BitConverter.ToUInt64(byteMsg));
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(6, valbyte);
+
+            valbyte = Packer.RxSignalUnpack(BitConverter.GetBytes(498806260540323729), sig);
+            Assert.AreEqual(6, valbyte);
         }
     }
 }

--- a/DbcParserLib.Tests/PackerTests.cs
+++ b/DbcParserLib.Tests/PackerTests.cs
@@ -371,5 +371,101 @@ namespace DbcParserLib.Tests
             valbyte = Packer.RxSignalUnpack(BitConverter.GetBytes(498806260540323729), sig);
             Assert.AreEqual(6, valbyte);
         }
+
+        [Test]
+        public void BytePackingBigEndianSmaller8Byte()
+        {
+            var messageLength = 5;
+
+            var sig = new Signal
+            {
+                Length = 12,
+                StartBit = 13,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+
+            var byteMsg = new byte[messageLength];
+
+            Packer.TxSignalPack(byteMsg, 4095, sig);
+            Assert.AreEqual(byteMsg, new byte[] { 0, 63, 252, 0, 0 });
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(4095, valbyte);
+        }
+
+        [Test]
+        public void BytePackingLittleEndianSmaller8Byte()
+        {
+            var messageLength = 5;
+
+            var sig = new Signal
+            {
+                Length = 12,
+                StartBit = 26,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 1,
+                Factor = 1,
+                Offset = 0
+            };
+
+            var byteMsg = new byte[messageLength];
+
+            Packer.TxSignalPack(byteMsg, 4095, sig);
+            Assert.AreEqual(byteMsg, new byte[] {0, 0, 0, 252, 63});
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(4095, valbyte);
+        }
+
+        [Test]
+        public void BytePackingBigEndianBigger8Byte()
+        {
+            var messageLength = 24;
+
+            var sig = new Signal
+            {
+                Length = 12,
+                StartBit = 138,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+
+            var byteMsg = new byte[messageLength];
+
+            Packer.TxSignalPack(byteMsg, 4095, sig);
+            Assert.AreEqual(byteMsg, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 255, 128, 0, 0, 0, 0 });
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(4095, valbyte);
+        }
+
+        [Test]
+        public void BytePackingLittleEndianBigger8Byte()
+        {
+            var messageLength = 24;
+
+            var sig = new Signal
+            {
+                Length = 12,
+                StartBit = 138,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 1,
+                Factor = 1,
+                Offset = 0
+            };
+
+            var byteMsg = new byte[messageLength];
+
+            Packer.TxSignalPack(byteMsg, 4095, sig);
+            Assert.AreEqual(byteMsg, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 252, 63, 0, 0, 0, 0, 0 });
+
+            var valbyte = Packer.RxSignalUnpack(byteMsg, sig);
+            Assert.AreEqual(4095, valbyte);
+        }
     }
 }

--- a/DbcParserLib.Tests/PackerTests.cs
+++ b/DbcParserLib.Tests/PackerTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using DbcParserLib.Model;
+using System;
 
 namespace DbcParserLib.Tests
 {
@@ -136,6 +137,66 @@ namespace DbcParserLib.Tests
 
             val = Packer.RxSignalUnpack(9655716608953581040, sig);
             Assert.AreEqual(800, val);
+        }
+
+        [Test]
+        public void SimplePackingMultiPackBigEndian()
+        {
+            var sig1 = new Signal
+            {
+                StartBit = 7,
+                Length = 10,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+
+            var sig2 = new Signal
+            {
+                StartBit = 13,
+                Length = 6,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+
+            var sig3 = new Signal
+            {
+                StartBit = 23,
+                Length = 32,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+
+            var sig4 = new Signal
+            {
+                StartBit = 55,
+                Length = 16,
+                ValueType = DbcValueType.Unsigned,
+                ByteOrder = 0,
+                Factor = 1,
+                Offset = 0
+            };
+
+            ulong TxMsg = 0;
+            TxMsg |= Packer.TxSignalPack(0, sig1);
+            TxMsg |= Packer.TxSignalPack(63, sig2);
+            TxMsg |= Packer.TxSignalPack(0, sig3);
+            TxMsg |= Packer.TxSignalPack(ushort.MaxValue, sig4);
+
+            Assert.AreEqual(18446462598732857088, TxMsg);
+
+            byte[] txMsg = new byte[8];
+            Packer.TxSignalPack(ref txMsg, 0, sig1);
+            Packer.TxSignalPack(ref txMsg, 63, sig2);
+            Packer.TxSignalPack(ref txMsg, 0, sig3);
+            Packer.TxSignalPack(ref txMsg, ushort.MaxValue, sig4);
+
+            Assert.AreEqual(18446462598732857088, BitConverter.ToUInt64(txMsg));
         }
 
         [Test]

--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -1,3 +1,7 @@
+using uint8_T = System.Byte;
+using uint16_T = System.UInt16;
+using int64_T = System.Int64;
+using uint64_T = System.UInt64;
 using System;
 using System.Runtime.InteropServices;
 using DbcParserLib.Model;
@@ -12,16 +16,16 @@ namespace DbcParserLib
         /// <param name="value">Value to be packed</param>
         /// <param name="signal">Signal containing dbc information</param>
         /// <returns>Returns a 64 bit unsigned data message</returns>
-        public static ulong TxSignalPack(double value, Signal signal)
+        public static uint64_T TxSignalPack(double value, Signal signal)
         {
-            long iVal = TxPackApplySignAndScale(value, signal);
-            ulong bitMask = signal.BitMask();
+            int64_T iVal = TxPackApplySignAndScale(value, signal);
+            uint64_T bitMask = signal.BitMask();
 
             // Pack signal
             if (signal.Intel()) // Little endian (Intel)
-                return (((ulong)iVal & bitMask) << signal.StartBit);
+                return (((uint64_T)iVal & bitMask) << signal.StartBit);
             else // Big endian (Motorola)
-                return MirrorMsg(((ulong)iVal & bitMask) << GetStartBitLE(signal));
+                return MirrorMsg(((uint64_T)iVal & bitMask) << GetStartBitLE(signal));
         }
 
         /// <summary>
@@ -32,25 +36,25 @@ namespace DbcParserLib
         /// <param name="signal">Signal containing dbc information</param>
         /// <remarks>Due to needing to reverse the byte array when handling BigEndian(Motorola) format this method can not be called in parallel for multiple signals in one message.
         /// To make this obvios the message is a ref and is actually reassigned after handling BigEndian format.</remarks>
-        public static void TxSignalPack(ref byte[] message, double value, Signal signal)
+        public static void TxSignalPack(ref uint8_T[] message, double value, Signal signal)
         {
-            long iVal = TxPackApplySignAndScale(value, signal);
+            int64_T iVal = TxPackApplySignAndScale(value, signal);
 
             // Pack signal
             if (!signal.Intel())
             {
-                var tempArray = new byte[message.Length];
+                var tempArray = new uint8_T[message.Length];
                 Array.Copy(message, tempArray, message.Length);
                 Array.Reverse(tempArray);
 
-                WriteBits(tempArray, unchecked((ulong)iVal), GetStartBitLE(signal, message.Length), signal.Length);
+                WriteBits(tempArray, unchecked((uint64_T)iVal), GetStartBitLE(signal, message.Length), signal.Length);
 
                 Array.Reverse(tempArray);
 
                 message = tempArray;
                 return;
             }
-            WriteBits(message, unchecked((ulong)iVal), signal.StartBit, signal.Length);
+            WriteBits(message, unchecked((uint64_T)iVal), signal.StartBit, signal.Length);
         }
 
         /// <summary>
@@ -59,9 +63,9 @@ namespace DbcParserLib
         /// <param name="value">Value to be packed</param>
         /// <param name="signal">Signal containing dbc information</param>
         /// <returns>Returns a 64 bit unsigned data message</returns>
-        public static ulong TxStatePack(ulong value, Signal signal)
+        public static uint64_T TxStatePack(uint64_T value, Signal signal)
         {
-            ulong bitMask = signal.BitMask();
+            uint64_T bitMask = signal.BitMask();
 
             // Apply overflow protection
             value = CLAMP(value, 0UL, bitMask);
@@ -79,10 +83,10 @@ namespace DbcParserLib
         /// <param name="RxMsg64">The 64 bit unsigned data message</param>
         /// <param name="signal">Signal containing dbc information</param>
         /// <returns>Returns a double value representing the unpacked signal</returns>
-        public static double RxSignalUnpack(ulong RxMsg64, Signal signal)
+        public static double RxSignalUnpack(uint64_T RxMsg64, Signal signal)
         {
-            ulong iVal;
-            ulong bitMask = signal.BitMask();
+            uint64_T iVal;
+            uint64_T bitMask = signal.BitMask();
 
             // Unpack signal
             if (signal.Intel()) // Little endian (Intel)
@@ -99,14 +103,14 @@ namespace DbcParserLib
         /// <param name="receiveMessage">The message data</param>
         /// <param name="signal">Signal containing dbc information</param>
         /// <returns>Returns a double value representing the unpacked signal</returns>
-        public static double RxSignalUnpack(byte[] receiveMessage, Signal signal)
+        public static double RxSignalUnpack(uint8_T[] receiveMessage, Signal signal)
         {
             var startBit = signal.StartBit;
             var message = receiveMessage;
 
             if (!signal.Intel())
             {
-                var tempArray = new byte[message.Length];
+                var tempArray = new uint8_T[message.Length];
                 Array.Copy(message, tempArray, message.Length);
                 Array.Reverse(tempArray);
 
@@ -125,10 +129,10 @@ namespace DbcParserLib
         /// <param name="RxMsg64">The 64 bit unsigned data message</param>
         /// <param name="signal">Signal containing dbc information</param>
         /// <returns>Returns an unsigned integer representing the unpacked state</returns>
-        public static ulong RxStateUnpack(ulong RxMsg64, Signal signal)
+        public static uint64_T RxStateUnpack(uint64_T RxMsg64, Signal signal)
         {
-            ulong iVal;
-            ulong bitMask = signal.BitMask();
+            uint64_T iVal;
+            uint64_T bitMask = signal.BitMask();
 
             // Unpack signal
             if (signal.Intel()) // Little endian (Intel)
@@ -139,10 +143,10 @@ namespace DbcParserLib
             return iVal;
         }
 
-        private static long TxPackApplySignAndScale(double value, Signal signal)
+        private static int64_T TxPackApplySignAndScale(double value, Signal signal)
         {
-            long iVal;
-            ulong bitMask = signal.BitMask();
+            int64_T iVal;
+            uint64_T bitMask = signal.BitMask();
 
             // Apply scaling
             var rawValue = (value - signal.Offset) / signal.Factor;
@@ -151,18 +155,18 @@ namespace DbcParserLib
             else if (signal.ValueType == DbcValueType.IEEEDouble)
                 iVal = DoubleConverter.AsInteger(rawValue);
             else
-                iVal = (long)Math.Round(rawValue);
+                iVal = (int64_T)Math.Round(rawValue);
 
             // Apply overflow protection
             if (signal.ValueType == DbcValueType.Signed)
-                iVal = CLAMP(iVal, -(long)(bitMask >> 1) - 1, (long)(bitMask >> 1));
+                iVal = CLAMP(iVal, -(int64_T)(bitMask >> 1) - 1, (int64_T)(bitMask >> 1));
             else if (signal.ValueType == DbcValueType.Unsigned)
-                iVal = CLAMP(iVal, 0L, (long)bitMask);
+                iVal = CLAMP(iVal, 0L, (int64_T)bitMask);
 
             // Manage sign bit (if signed)
             if (signal.ValueType == DbcValueType.Signed && iVal < 0)
             {
-                iVal += (long)(1UL << signal.Length);
+                iVal += (int64_T)(1UL << signal.Length);
             }
 
             return iVal;
@@ -173,10 +177,10 @@ namespace DbcParserLib
             switch (signal.ValueType)
             {
                 case DbcValueType.Signed:
-                    long signedValue;
+                    int64_T signedValue;
                     if (signal.Length == 64)
                     {
-                        signedValue = unchecked((long)value);
+                        signedValue = unchecked((int64_T)value);
                     }
                     else
                     {
@@ -190,18 +194,18 @@ namespace DbcParserLib
                 case DbcValueType.IEEEFloat:
                     return FloatConverter.AsFloatingPoint((int)value) * signal.Factor + signal.Offset;
                 case DbcValueType.IEEEDouble:
-                    return DoubleConverter.AsFloatingPoint(unchecked((long)value)) * signal.Factor + signal.Offset;
+                    return DoubleConverter.AsFloatingPoint(unchecked((int64_T)value)) * signal.Factor + signal.Offset;
                 default:
                     return (double)(value * (decimal)signal.Factor + (decimal)signal.Offset);
             }            
         }
 
-        private static long CLAMP(long x, long low, long high)
+        private static int64_T CLAMP(int64_T x, int64_T low, int64_T high)
         {
             return Math.Max(low, Math.Min(x, high));
         }
 
-        private static ulong CLAMP(ulong x, ulong low, ulong high)
+        private static uint64_T CLAMP(uint64_T x, uint64_T low, uint64_T high)
         {
             return Math.Max(low, Math.Min(x, high));
         }
@@ -209,39 +213,39 @@ namespace DbcParserLib
         /// <summary>
         /// Mirror data message. It is used to convert Big endian to Little endian and vice-versa
         /// </summary>
-        private static ulong MirrorMsg(ulong msg)
+        private static uint64_T MirrorMsg(uint64_T msg)
         {
-            byte[] v =
+            uint8_T[] v =
             {
-                (byte)msg,
-                (byte)(msg >> 8),
-                (byte)(msg >> 16),
-                (byte)(msg >> 24),
-                (byte)(msg >> 32),
-                (byte)(msg >> 40),
-                (byte)(msg >> 48),
-                (byte)(msg >> 56)
+                (uint8_T)msg,
+                (uint8_T)(msg >> 8),
+                (uint8_T)(msg >> 16),
+                (uint8_T)(msg >> 24),
+                (uint8_T)(msg >> 32),
+                (uint8_T)(msg >> 40),
+                (uint8_T)(msg >> 48),
+                (uint8_T)(msg >> 56)
             };
-            return (((ulong)v[0] << 56)
-                    | ((ulong)v[1] << 48)
-                    | ((ulong)v[2] << 40)
-                    | ((ulong)v[3] << 32)
-                    | ((ulong)v[4] << 24)
-                    | ((ulong)v[5] << 16)
-                    | ((ulong)v[6] << 8)
-                    | (ulong)v[7]);
+            return (((uint64_T)v[0] << 56)
+                    | ((uint64_T)v[1] << 48)
+                    | ((uint64_T)v[2] << 40)
+                    | ((uint64_T)v[3] << 32)
+                    | ((uint64_T)v[4] << 24)
+                    | ((uint64_T)v[5] << 16)
+                    | ((uint64_T)v[6] << 8)
+                    | (uint64_T)v[7]);
         }
 
         /// <summary>
         /// Get start bit Little Endian
         /// </summary>
-        private static byte GetStartBitLE(Signal signal, int messageByteCount = 8)
+        private static uint16_T GetStartBitLE(Signal signal, int messageByteCount = 8)
         {
-            byte startByte = (byte)(signal.StartBit / 8);
-            return (byte)(8 * messageByteCount - (signal.Length + 8 * startByte + (8 * (startByte + 1) - (signal.StartBit + 1)) % 8));
+            uint16_T startByte = (uint16_T)(signal.StartBit / 8);
+            return (uint16_T)(8 * messageByteCount - (signal.Length + 8 * startByte + (8 * (startByte + 1) - (signal.StartBit + 1)) % 8));
         }
 
-        private static void WriteBits(byte[] data, ulong value, int startBit, int length)
+        private static void WriteBits(uint8_T[] data, uint64_T value, int startBit, int length)
         {
             for (int bitIndex = 0; bitIndex < length; bitIndex++)
             {
@@ -250,16 +254,16 @@ namespace DbcParserLib
                 int bitInBytePosition = bitPosition % 8;
 
                 // Extract the bit from the signal value
-                ulong bitValue = (value >> bitIndex) & 1;
+                uint64_T bitValue = (value >> bitIndex) & 1;
 
                 // Set the bit in the message
                 data[byteIndex] |= (byte)(bitValue << bitInBytePosition);
             }
         }
 
-        private static ulong ExtractBits(byte[] data, int startBit, int length)
+        private static uint64_T ExtractBits(uint8_T[] data, int startBit, int length)
         {
-            ulong result = 0;
+            uint64_T result = 0;
             int bitIndex = 0;
 
             for (int bitPos = startBit; bitPos < startBit + length; bitPos++)
@@ -303,15 +307,15 @@ namespace DbcParserLib
     [StructLayout(LayoutKind.Explicit)]
     public class DoubleConverter
     {
-        [FieldOffset(0)] public long Integer;
+        [FieldOffset(0)] public int64_T Integer;
         [FieldOffset(0)] public double Float;
 
-        public static long AsInteger(double value)
+        public static int64_T AsInteger(double value)
         {
             return new DoubleConverter() { Float = value }.Integer;
         }
 
-        public static double AsFloatingPoint(long value)
+        public static double AsFloatingPoint(int64_T value)
         {
             return new DoubleConverter() { Integer = value }.Float;
         }

--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -207,6 +207,22 @@ namespace DbcParserLib
             return (uint8_T)(8 * messageByteCount - (signal.Length + 8 * startByte + (8 * (startByte + 1) - (signal.StartBit + 1)) % 8));
         }
 
+        private static void WriteBits(byte[] data, ulong value, int startBit, int length)
+        {
+            for (int bitIndex = 0; bitIndex < length; bitIndex++)
+            {
+                int bitPosition = startBit + bitIndex;
+                int byteIndex = bitPosition / 8;
+                int bitInBytePosition = bitPosition % 8;
+
+                // Extract the bit from the signal value
+                ulong bitValue = (value >> bitIndex) & 1;
+
+                // Set the bit in the message
+                data[byteIndex] |= (byte)(bitValue << bitInBytePosition);
+            }
+        }
+
         private static ulong ExtractBits(byte[] data, int startBit, int length)
         {
             ulong result = 0;

--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -134,11 +134,6 @@ namespace DbcParserLib
             return ApplySignAndScale(signal, iVal);
         }
 
-        public static double ApplyLimit(double value, Signal signal)
-        {
-            return Math.Max(signal.Minimum, Math.Min(value, signal.Maximum));
-        }
-
         private static double ApplySignAndScale(Signal signal, ulong value)
         {
             switch (signal.ValueType)

--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -4,7 +4,6 @@ using uint64_T = System.UInt64;
 using System;
 using System.Runtime.InteropServices;
 using DbcParserLib.Model;
-using System.Linq;
 
 namespace DbcParserLib
 {
@@ -117,16 +116,20 @@ namespace DbcParserLib
         /// <returns>Returns a double value representing the unpacked signal</returns>
         public static double RxSignalUnpack(byte[] receiveMessage, Signal signal)
         {
-            var bitMask = signal.BitMask();
             var startBit = signal.StartBit;
+            var message = receiveMessage;
 
             if (!signal.Intel())
             {
-                receiveMessage = receiveMessage.Reverse().ToArray();
-                startBit = GetStartBitLE(signal, receiveMessage.Length);
+                var copyArray = new byte[message.Length];
+                Array.Copy(message, copyArray, message.Length);
+                Array.Reverse(copyArray);
+
+                message = copyArray;
+                startBit = GetStartBitLE(signal, message.Length);
             }
 
-            var iVal = ExtractBits(receiveMessage, startBit, signal.Length);
+            var iVal = ExtractBits(message, startBit, signal.Length);
 
             return ApplySignAndScale(signal, iVal);
         }

--- a/DbcParserLib/Packer.cs
+++ b/DbcParserLib/Packer.cs
@@ -34,24 +34,16 @@ namespace DbcParserLib
         /// <param name="message">A ref to the byte array containing the message</param>
         /// <param name="value">Value to be packed</param>
         /// <param name="signal">Signal containing dbc information</param>
-        /// <remarks>Due to needing to reverse the byte array when handling BigEndian(Motorola) format this method can not be called in parallel for multiple signals in one message.
-        /// To make this obvios the message is a ref and is actually reassigned after handling BigEndian format.</remarks>
-        public static void TxSignalPack(ref uint8_T[] message, double value, Signal signal)
+        public static void TxSignalPack(uint8_T[] message, double value, Signal signal)
         {
             int64_T iVal = TxPackApplySignAndScale(value, signal);
 
             // Pack signal
             if (!signal.Intel())
             {
-                var tempArray = new uint8_T[message.Length];
-                Array.Copy(message, tempArray, message.Length);
-                Array.Reverse(tempArray);
-
-                WriteBits(tempArray, unchecked((uint64_T)iVal), GetStartBitLE(signal, message.Length), signal.Length);
-
-                Array.Reverse(tempArray);
-
-                message = tempArray;
+                Array.Reverse(message);
+                WriteBits(message, unchecked((uint64_T)iVal), GetStartBitLE(signal, message.Length), signal.Length);
+                Array.Reverse(message);
                 return;
             }
             WriteBits(message, unchecked((uint64_T)iVal), signal.StartBit, signal.Length);


### PR DESCRIPTION
This adds some new functions for packing/unpacking can messages based on byte arrays and does also support message lengths != 64 bit. 

For me this is considered a base implementation that could be used to build on. (E.g. Message encode/decode function)

I also added a new benchmark project to the solution using dotnetbenchmark. This is optional but could help to tune performance in the future.

resolves #67 (but could be extended in the future to implement message packing aso.)