### PR TITLE
Update Target framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: ✨ Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
           
       - name: 🚚 DbcParserLib Restore
         run: dotnet restore DbcParserLib.Tests

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,7 +17,7 @@ jobs:
       - name: ✨ Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: 🛠️ Setup NuGet
         uses: nuget/setup-nuget@v1

--- a/DbcParserLib.Benchmarks/DbcParserLib.Benchmarks.csproj
+++ b/DbcParserLib.Benchmarks/DbcParserLib.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/DbcParserLib.Tests/DbcParserLib.Tests.csproj
+++ b/DbcParserLib.Tests/DbcParserLib.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/DbcParserLib/DbcParserLib.csproj
+++ b/DbcParserLib/DbcParserLib.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net461;net5.0;net6.0</TargetFrameworks>
+	  <OutputType>Library</OutputType>
+    <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0</TargetFrameworks>
     <Authors>Emanuel Feru</Authors>
     <Description>DbcParserLib is a .NET dbc file parser library for CAN bus network signals. This library can also be used to pack and unpack CAN signals.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 


### PR DESCRIPTION
Now as a seperate pull request

Using .net8.0 as default for all projects instead of .net6.0 as .net8.0 is now the current version with .net6.0 losing support soon
Updated using target frameworks for the main project as discussed in #69 to solve #69

Will require changes in the github chain as .net8.0 will fail the current validation chain