### PR TITLE
Fix parsing for val table definition without a space before line termination

### DIFF
--- a/DbcParserLib.Tests/ValueTableLineParserTests.cs
+++ b/DbcParserLib.Tests/ValueTableLineParserTests.cs
@@ -320,11 +320,11 @@ namespace DbcParserLib.Tests
             lineParser.TryParse(line, dbcBuilder, nextLineProviderMock.Object);
         }
 
-        [TestCase("VAL_TABLE_ tableName 0 \"Running\" 1 \"Idle\";")]
         [TestCase("VAL_TABLE_ tableName 0 \"Running\" 1 \"Idle\"")]
         [TestCase("VAL_TABLE_ tableName 0 \"Running\" 1 Idle;")]
         [TestCase("VAL_TABLE_ \"tableName\" 0 \"Running\" 1 \"Idle\" ;")]
         [TestCase("VAL_TABLE_ tableName 0 \"Running\" 1.5 \"Idle\" ;")]
+        [TestCase("VAL_TABLE_ tableName 0 \"Running\"1 \"Idle\";")]
         public void ValueTableDefinitionSyntaxErrorIsObserved(string line)
         {
             var observerMock = m_repository.Create<IParseFailureObserver>();
@@ -359,6 +359,21 @@ namespace DbcParserLib.Tests
         {
             var tableName = "tableName";
             var line = $"VAL_TABLE_ {tableName} 0 \"Running\" 1 \"Idle\"  ;";
+
+            var observerMock = m_repository.Create<IParseFailureObserver>();
+            var nextLineProviderMock = m_repository.Create<INextLineProvider>();
+            var dbcBuilder = new DbcBuilder(observerMock.Object);
+
+            var lineParser = new ValueTableDefinitionLineParser(observerMock.Object);
+
+            Assert.That(lineParser.TryParse(line, dbcBuilder, nextLineProviderMock.Object), Is.True);
+        }
+
+        [Test]
+        public void ValueTableDefinitionContainsNoSpacesBeforeSemicolon()
+        {
+            var tableName = "tableName";
+            var line = $"VAL_TABLE_ {tableName} 0 \"Running\" 1 \"Idle\";";
 
             var observerMock = m_repository.Create<IParseFailureObserver>();
             var nextLineProviderMock = m_repository.Create<INextLineProvider>();


### PR DESCRIPTION
Should be very much the same code change as the one @Whitehouse112 did in:
https://github.com/EFeru/DbcParser/commit/2f7f295f3651112d44c024890c085268ead2c762
but now for value table definitions. Fixing one of the parsing error i reported in #82 which is allready closed