### PR TITLE
Update ExtensionsAndHelpers.cs to fix cycleTime problem

### DIFF
--- a/DbcParserLib/ExtensionsAndHelpers.cs
+++ b/DbcParserLib/ExtensionsAndHelpers.cs
@@ -80,11 +80,18 @@ namespace DbcParserLib
 
             if (message.CustomProperties.TryGetValue("GenMsgCycleTime", out var property))
             {
-                cycleTime = property.IntegerCustomProperty.Value;
-                return true;
+                if (property.IntegerCustomProperty != null)
+                {
+                    cycleTime = property.IntegerCustomProperty.Value;
+                    return true;
+                }
+                else if (property.FloatCustomProperty != null)
+                {
+                    cycleTime = (int)property.FloatCustomProperty.Value;
+                    return true;
+                }
             }
-            else
-                return false;
+            return false;
         }
 
         internal static bool InitialValue(this Signal signal, out double initialValue)


### PR DESCRIPTION
When the cycletime is defined as a FLOAT type, the original code will not be able to read the cycletime and will report an error, I added a little bit of judgment to make it able to read the FLOAT type cycletime