### PR TITLE
#97 Updated comment parser regex

### DIFF
--- a/DbcParserLib/Helpers.cs
+++ b/DbcParserLib/Helpers.cs
@@ -9,34 +9,22 @@ namespace DbcParserLib
         public const string Comma = ",";
         public const string DoubleQuotes = "\"";
 
-        private static readonly string[] SpaceArray = new[] { Space };
+        private static readonly string[] SpaceArray = { Space };
 
         public static string[] SplitBySpace(this string value)
         {
             return value.Split(SpaceArray, System.StringSplitOptions.RemoveEmptyEntries);
         }
-
-        public static string ConvertToMultiLine(string[] records, int offset)
-        {
-            var sb = new StringBuilder();
-            for (var i = offset; i < records.Length - 1; i += 2)
-            {
-                sb.AppendFormat("{0} {1} {2}", records[i], records[i+1], '\n');
-            }
-
-            return sb.ToString();
-        }
-
+        
         public static string ConcatenateTextComment(string[] strings, int startingIndex)
         {
             var sb = new StringBuilder();
-            foreach(var s in strings )
+            foreach(var s in strings)
             {
-                sb.AppendLine(Regex.Replace(s, @"""|;", ""));
+                sb.AppendLine(Regex.Replace(s, @"""", ""));
             }
             var commentText = sb.ToString().Substring(startingIndex);
-            return commentText.Substring(0, commentText.Length - 2);
+            return commentText.Substring(0, commentText.Length - 3);
         }
     }
-
 }

--- a/DbcParserLib/Parsers/PropertiesDefinitionLineParser.cs
+++ b/DbcParserLib/Parsers/PropertiesDefinitionLineParser.cs
@@ -1,7 +1,6 @@
 ﻿using DbcParserLib.Model;
 using DbcParserLib.Observers;
 using System;
-using System.ComponentModel;
 using System.Globalization;
 using System.Text.RegularExpressions;
 


### PR DESCRIPTION
- Updated comment parser regex to allow semicolon inside comment string (single and multiline comment)
- Removed wrong tests allowing comment to be written without quotation marks
- Added some tests