### PR TITLE
Make `Parser.ParseFromReader` public

### DIFF
--- a/DbcParserLib/Parser.cs
+++ b/DbcParserLib/Parser.cs
@@ -60,7 +60,7 @@ namespace DbcParserLib
             }
         }
 
-        private static Dbc ParseFromReader(TextReader reader)
+        public static Dbc ParseFromReader(TextReader reader)
         {
             CreateLineParsers();
             m_parseObserver.Clear();


### PR DESCRIPTION
Reasons for this change:
- Method `Parser.ParseFromReader` is the only parsing method that allows user to specify encoding. All other methods assume default encoding.
- This is the base parsing method. I don't see a reason to have it as `private`. This only restricts the user.
- Currently to bypass inability to specify encoding you would have to load whole file into a string with specifed encoding, and then use `Parser.Parse` to parse from string. This is wasteful memory-wise.