### PR TITLE
Update ExtensionsAndHelpers.cs to fix cycleTime problem

### DIFF
--- a/DbcParserLib/ExtensionsAndHelpers.cs
+++ b/DbcParserLib/ExtensionsAndHelpers.cs
@@ -80,11 +80,18 @@ namespace DbcParserLib
 
             if (message.CustomProperties.TryGetValue("GenMsgCycleTime", out var property))
             {
-                cycleTime = property.IntegerCustomProperty.Value;
-                return true;
+                if (property.IntegerCustomProperty != null)
+                {
+                    cycleTime = property.IntegerCustomProperty.Value;
+                    return true;
+                }
+                else if (property.FloatCustomProperty != null)
+                {
+                    cycleTime = (int)property.FloatCustomProperty.Value;
+                    return true;
+                }
             }
-            else
-                return false;
+            return false;
         }
 
         internal static bool InitialValue(this Signal signal, out double initialValue)

--- a/README.md
+++ b/README.md
@@ -192,3 +192,8 @@ Contributions are appreciated! Feel free to create pull requests to improve this
 This project is supported by JetBrains for Open Source development
 
 ![JetBrains Logo (Main) logo](https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.svg)
+
+
+## [![Repography logo](https://images.repography.com/logo.svg)](https://repography.com) / Structure
+[![Structure](https://images.repography.com/59604055/Starkxim/DbcParser/structure/MX6Ur434fIKjggD8pMTN2zwJarX0HuHaJX8yWh6pkvo/l6Wvd3xA8xT20EM4qYEyhEIEQt7FC5tTA93o6pFOIfs_table.svg)](https://github.com/Starkxim/DbcParser)
+

--- a/README.md
+++ b/README.md
@@ -192,8 +192,3 @@ Contributions are appreciated! Feel free to create pull requests to improve this
 This project is supported by JetBrains for Open Source development
 
 ![JetBrains Logo (Main) logo](https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.svg)
-
-
-## [![Repography logo](https://images.repography.com/logo.svg)](https://repography.com) / Structure
-[![Structure](https://images.repography.com/59604055/Starkxim/DbcParser/structure/MX6Ur434fIKjggD8pMTN2zwJarX0HuHaJX8yWh6pkvo/l6Wvd3xA8xT20EM4qYEyhEIEQt7FC5tTA93o6pFOIfs_table.svg)](https://github.com/Starkxim/DbcParser)
-


### PR DESCRIPTION
When the cycletime is defined as a FLOAT type, the original code will not be able to read the cycletime and will report an error, I added a little bit of judgment to make it able to read the FLOAT type cycletime